### PR TITLE
Optimize mass-query handling and fix Nix package

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,14 @@ priority = 20
 db_path = "/var/lib/ncro/routes.db"
 max_entries = 100000 # LRU eviction above this
 ttl = "1h" # how long a routing decision is trusted
+negative_ttl = "10m" # cache misses for a short window
 latency_alpha = 0.3 # EMA smoothing factor (0 < alpha < 1)
+
+[cache.mass_query]
+max_concurrent_races = 64 # total concurrent narinfo races
+per_upstream_max_inflight = 8 # per-upstream narinfo head concurrency
+in_memory_negative_ttl = "5s" # short-lived miss suppression
+upstream_cooldown = "15s" # cooldown on transient upstream network errors
 
 [logging]
 level = "info" # debug | info | warn | error

--- a/config.example.toml
+++ b/config.example.toml
@@ -20,6 +20,12 @@ max_entries   = 100000
 negative_ttl  = "10m"
 ttl           = "1h"
 
+[cache.mass_query]
+in_memory_negative_ttl    = "5s"
+max_concurrent_races      = 64
+per_upstream_max_inflight = 8
+upstream_cooldown         = "15s"
+
 [discovery]
 discovery_time = "5s"
 domain         = "local"

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -37,6 +37,22 @@ mod tests {
     assert_eq!(cfg.cache.ttl.0, Duration::from_secs(7200));
     Ok(())
   }
+
+  #[test]
+  fn validates_mass_query_limits() -> Result<(), toml::de::Error> {
+    let cfg: Config = toml::from_str(
+      "[cache.mass_query]\nmax_concurrent_races = \
+       0\nper_upstream_max_inflight = 1\nin_memory_negative_ttl = \
+       \"5s\"\nupstream_cooldown = \"10s\"\n",
+    )?;
+    let err = cfg.validate().expect_err("expected validation failure");
+    assert!(
+      err
+        .to_string()
+        .contains("cache.mass_query.max_concurrent_races must be >= 1")
+    );
+    Ok(())
+  }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -93,6 +109,7 @@ pub struct CacheConfig {
   pub ttl:           HumanDuration,
   pub negative_ttl:  HumanDuration,
   pub latency_alpha: f64,
+  pub mass_query:    MassQueryConfig,
 }
 
 impl Default for CacheConfig {
@@ -103,6 +120,27 @@ impl Default for CacheConfig {
       ttl:           HumanDuration(Duration::from_secs(60 * 60)),
       negative_ttl:  HumanDuration(Duration::from_secs(10 * 60)),
       latency_alpha: 0.3,
+      mass_query:    MassQueryConfig::default(),
+    }
+  }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct MassQueryConfig {
+  pub max_concurrent_races:      u32,
+  pub per_upstream_max_inflight: u32,
+  pub in_memory_negative_ttl:    HumanDuration,
+  pub upstream_cooldown:         HumanDuration,
+}
+
+impl Default for MassQueryConfig {
+  fn default() -> Self {
+    Self {
+      max_concurrent_races:      64,
+      per_upstream_max_inflight: 8,
+      in_memory_negative_ttl:    HumanDuration(Duration::from_secs(5)),
+      upstream_cooldown:         HumanDuration(Duration::from_secs(15)),
     }
   }
 }
@@ -295,6 +333,26 @@ impl Config {
     if self.cache.max_entries <= 0 {
       return Err(ConfigError::Validation(
         "cache.max_entries must be positive".to_string(),
+      ));
+    }
+    if self.cache.mass_query.max_concurrent_races == 0 {
+      return Err(ConfigError::Validation(
+        "cache.mass_query.max_concurrent_races must be >= 1".to_string(),
+      ));
+    }
+    if self.cache.mass_query.per_upstream_max_inflight == 0 {
+      return Err(ConfigError::Validation(
+        "cache.mass_query.per_upstream_max_inflight must be >= 1".to_string(),
+      ));
+    }
+    if self.cache.mass_query.in_memory_negative_ttl.0.is_zero() {
+      return Err(ConfigError::Validation(
+        "cache.mass_query.in_memory_negative_ttl must be positive".to_string(),
+      ));
+    }
+    if self.cache.mass_query.upstream_cooldown.0.is_zero() {
+      return Err(ConfigError::Validation(
+        "cache.mass_query.upstream_cooldown must be positive".to_string(),
       ));
     }
     if self.mesh.enabled && self.mesh.peers.is_empty() {

--- a/crates/mesh/src/lib.rs
+++ b/crates/mesh/src/lib.rs
@@ -235,3 +235,67 @@ fn decode_packet(packet: &[u8]) -> Result<DecodedPacket<'_>, MeshError> {
   let msg = rmp_serde::from_slice(body)?;
   Ok((pubkey, sig, body, msg))
 }
+
+#[cfg(test)]
+mod tests {
+  #![expect(clippy::unwrap_used, reason = "Fine in tests")]
+  use ncro_db::{Db, RouteEntry};
+
+  use super::merge_routes;
+
+  fn route(store_path: &str, latency_ema: f64, ttl_secs: i64) -> RouteEntry {
+    let now = chrono::Utc::now();
+    RouteEntry {
+      store_path: store_path.into(),
+      upstream_url: "http://test.example.com".into(),
+      latency_ms: latency_ema,
+      latency_ema,
+      last_verified: now,
+      query_count: 1,
+      failure_count: 0,
+      ttl: now + chrono::Duration::seconds(ttl_secs),
+      nar_hash: "sha256:aabbcc".into(),
+      nar_size: 42,
+      nar_url: "nar/test.nar".into(),
+      narinfo_bytes: None,
+    }
+  }
+
+  #[tokio::test]
+  async fn merge_routes_inserts_new_route() {
+    let db = Db::open(":memory:", 100).await.unwrap();
+    merge_routes(&db, vec![route("abc123", 10.0, 3600)]).await;
+    assert!(db.get_route("abc123").await.unwrap().is_some());
+  }
+
+  #[tokio::test]
+  async fn merge_routes_skips_expired_route() {
+    let db = Db::open(":memory:", 100).await.unwrap();
+    merge_routes(&db, vec![route("abc123", 10.0, -1)]).await;
+    assert!(db.get_route("abc123").await.unwrap().is_none());
+  }
+
+  #[tokio::test]
+  async fn merge_routes_does_not_overwrite_lower_latency() {
+    let db = Db::open(":memory:", 100).await.unwrap();
+    db.set_route(&route("abc123", 5.0, 3600)).await.unwrap();
+    merge_routes(&db, vec![route("abc123", 20.0, 3600)]).await;
+    let got = db.get_route("abc123").await.unwrap().unwrap();
+    assert_eq!(
+      got.latency_ema, 5.0,
+      "worse incoming must not overwrite better existing"
+    );
+  }
+
+  #[tokio::test]
+  async fn merge_routes_overwrites_higher_latency() {
+    let db = Db::open(":memory:", 100).await.unwrap();
+    db.set_route(&route("abc123", 20.0, 3600)).await.unwrap();
+    merge_routes(&db, vec![route("abc123", 5.0, 3600)]).await;
+    let got = db.get_route("abc123").await.unwrap().unwrap();
+    assert_eq!(
+      got.latency_ema, 5.0,
+      "better incoming must overwrite worse existing"
+    );
+  }
+}

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -13,14 +13,19 @@ use prometheus::{
 };
 
 pub struct Metrics {
-  registry:                 Registry,
-  pub narinfo_cache_hits:   IntCounter,
-  pub narinfo_cache_misses: IntCounter,
-  pub narinfo_requests:     IntCounterVec,
-  pub nar_requests:         IntCounter,
-  pub upstream_race_wins:   IntCounterVec,
-  pub route_entries:        IntGauge,
-  pub upstream_latency:     HistogramVec,
+  registry:                                  Registry,
+  pub narinfo_cache_hits:                    IntCounter,
+  pub narinfo_cache_misses:                  IntCounter,
+  pub narinfo_memory_negative_hits:          IntCounter,
+  pub narinfo_singleflight_waiters:          IntCounter,
+  pub narinfo_requests:                      IntCounterVec,
+  pub nar_requests:                          IntCounter,
+  pub narinfo_upstream_attempts:             IntCounter,
+  pub narinfo_upstream_attempts_per_resolve: HistogramVec,
+  pub narinfo_race_wait_seconds:             HistogramVec,
+  pub upstream_race_wins:                    IntCounterVec,
+  pub route_entries:                         IntGauge,
+  pub upstream_latency:                      HistogramVec,
 }
 
 static METRICS: OnceLock<Metrics> = OnceLock::new();
@@ -43,6 +48,16 @@ pub fn get() -> &'static Metrics {
       "Narinfo requests requiring upstream race.",
     )
     .expect("valid metric");
+    let narinfo_memory_negative_hits = IntCounter::new(
+      "ncro_narinfo_memory_negative_hits_total",
+      "Narinfo requests denied by short-lived in-memory negative cache.",
+    )
+    .expect("valid metric");
+    let narinfo_singleflight_waiters = IntCounter::new(
+      "ncro_narinfo_singleflight_waiters_total",
+      "Narinfo requests that waited on an in-flight same-hash lookup.",
+    )
+    .expect("valid metric");
     let narinfo_requests = IntCounterVec::new(
       Opts::new("ncro_narinfo_requests_total", "Narinfo requests by status."),
       &["status"],
@@ -51,6 +66,27 @@ pub fn get() -> &'static Metrics {
     let nar_requests =
       IntCounter::new("ncro_nar_requests_total", "NAR streaming requests.")
         .expect("valid metric");
+    let narinfo_upstream_attempts = IntCounter::new(
+      "ncro_narinfo_upstream_attempts_total",
+      "Total upstream narinfo attempts made during races.",
+    )
+    .expect("valid metric");
+    let narinfo_upstream_attempts_per_resolve = HistogramVec::new(
+      HistogramOpts::new(
+        "ncro_narinfo_upstream_attempts_per_resolve",
+        "Upstream attempts per narinfo resolution.",
+      ),
+      &["result"],
+    )
+    .expect("valid metric");
+    let narinfo_race_wait_seconds = HistogramVec::new(
+      HistogramOpts::new(
+        "ncro_narinfo_race_wait_seconds",
+        "Time spent waiting for race concurrency permit.",
+      ),
+      &["kind"],
+    )
+    .expect("valid metric");
     let upstream_race_wins = IntCounterVec::new(
       Opts::new(
         "ncro_upstream_race_wins_total",
@@ -77,8 +113,13 @@ pub fn get() -> &'static Metrics {
       Box::new(narinfo_cache_hits.clone())
         as Box<dyn prometheus::core::Collector>,
       Box::new(narinfo_cache_misses.clone()),
+      Box::new(narinfo_memory_negative_hits.clone()),
+      Box::new(narinfo_singleflight_waiters.clone()),
       Box::new(narinfo_requests.clone()),
       Box::new(nar_requests.clone()),
+      Box::new(narinfo_upstream_attempts.clone()),
+      Box::new(narinfo_upstream_attempts_per_resolve.clone()),
+      Box::new(narinfo_race_wait_seconds.clone()),
       Box::new(upstream_race_wins.clone()),
       Box::new(route_entries.clone()),
       Box::new(upstream_latency.clone()),
@@ -90,8 +131,13 @@ pub fn get() -> &'static Metrics {
       registry,
       narinfo_cache_hits,
       narinfo_cache_misses,
+      narinfo_memory_negative_hits,
+      narinfo_singleflight_waiters,
       narinfo_requests,
       nar_requests,
+      narinfo_upstream_attempts,
+      narinfo_upstream_attempts_per_resolve,
+      narinfo_race_wait_seconds,
       upstream_race_wins,
       route_entries,
       upstream_latency,

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -461,8 +461,9 @@ impl Router {
     winner: RaceResult,
     store_hash: &str,
   ) -> Result<ResolveResult, RouterError> {
-    let (body, nar_url, nar_hash, nar_size) =
+    let (body, raw_nar_url, nar_hash, nar_size) =
       self.fetch_narinfo(&winner.url, store_hash).await?;
+    let nar_url = raw_nar_url.trim_start_matches('/').to_string();
 
     ncro_metrics::get()
       .upstream_race_wins

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -5,14 +5,14 @@ use std::{
 };
 
 use chrono::Utc;
-use dashmap::DashMap;
+use dashmap::{DashMap, mapref::entry::Entry};
 use futures_util::{StreamExt, stream::FuturesUnordered};
 use moka::future::Cache as MokaCache;
 use ncro_db::{Db, DbError, RouteEntry};
 use ncro_health::{Prober, Status};
 use ncro_narinfo::{NarInfo, NarInfoError, parse_public_key};
 use thiserror::Error;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{Mutex, RwLock, Semaphore};
 
 #[derive(Debug, Error)]
 pub enum RouterError {
@@ -45,16 +45,30 @@ pub struct Router {
   inner: Arc<RouterInner>,
 }
 
+#[derive(Debug, Clone)]
+pub struct RouterTuning {
+  pub max_concurrent_races:      u32,
+  pub per_upstream_max_inflight: u32,
+  pub in_memory_negative_ttl:    Duration,
+  pub upstream_cooldown:         Duration,
+}
+
 struct RouterInner {
-  db:            Db,
-  prober:        Prober,
-  route_ttl:     Duration,
-  race_timeout:  Duration,
-  negative_ttl:  Duration,
-  client:        reqwest::Client,
-  upstream_keys: RwLock<HashMap<String, String>>,
-  inflight:      DashMap<String, Arc<Mutex<()>>>,
-  lru:           MokaCache<String, Arc<ResolveResult>>,
+  db:                       Db,
+  prober:                   Prober,
+  route_ttl:                Duration,
+  race_timeout:             Duration,
+  negative_ttl:             Duration,
+  client:                   reqwest::Client,
+  upstream_keys:            RwLock<HashMap<String, String>>,
+  inflight:                 DashMap<String, Arc<Mutex<()>>>,
+  lru:                      MokaCache<String, Arc<ResolveResult>>,
+  miss_lru:                 MokaCache<String, ()>,
+  race_semaphore:           Arc<Semaphore>,
+  per_upstream_limit:       u32,
+  upstream_semaphores:      DashMap<String, Arc<Semaphore>>,
+  upstream_cooldown:        DashMap<String, Instant>,
+  upstream_cooldown_window: Duration,
 }
 
 #[derive(Debug)]
@@ -74,6 +88,12 @@ enum RaceGroupError {
   NetworkError,
   /// The race deadline expired before any upstream responded.
   Timeout,
+}
+
+enum RaceAttempt {
+  Winner(RaceResult),
+  NotFound,
+  NetworkError { upstream: String },
 }
 
 struct InflightGuard<'a> {
@@ -102,6 +122,7 @@ impl Router {
     route_ttl: Duration,
     race_timeout: Duration,
     negative_ttl: Duration,
+    tuning: RouterTuning,
   ) -> Result<Self, reqwest::Error> {
     Ok(Self {
       inner: Arc::new(RouterInner {
@@ -117,6 +138,17 @@ impl Router {
           .max_capacity(1024)
           .time_to_live(route_ttl)
           .build(),
+        miss_lru: MokaCache::builder()
+          .max_capacity(32_768)
+          .time_to_live(tuning.in_memory_negative_ttl)
+          .build(),
+        race_semaphore: Arc::new(Semaphore::new(
+          usize::try_from(tuning.max_concurrent_races).unwrap_or(64),
+        )),
+        per_upstream_limit: tuning.per_upstream_max_inflight,
+        upstream_semaphores: DashMap::new(),
+        upstream_cooldown: DashMap::new(),
+        upstream_cooldown_window: tuning.upstream_cooldown,
       }),
     })
   }
@@ -141,6 +173,10 @@ impl Router {
     store_hash: &str,
     candidates: &[String],
   ) -> Result<ResolveResult, RouterError> {
+    if self.inner.miss_lru.get(store_hash).await.is_some() {
+      ncro_metrics::get().narinfo_memory_negative_hits.inc();
+      return Err(RouterError::NotFound);
+    }
     if self.inner.db.is_negative(store_hash).await? {
       return Err(RouterError::NotFound);
     }
@@ -149,14 +185,16 @@ impl Router {
     }
     ncro_metrics::get().narinfo_cache_misses.inc();
 
-    let lock = Arc::clone(
-      self
-        .inner
-        .inflight
-        .entry(store_hash.to_string())
-        .or_insert_with(|| Arc::new(Mutex::new(())))
-        .value(),
-    );
+    let lock = match self.inner.inflight.entry(store_hash.to_string()) {
+      Entry::Occupied(entry) => {
+        ncro_metrics::get().narinfo_singleflight_waiters.inc();
+        Arc::clone(entry.get())
+      },
+      Entry::Vacant(entry) => {
+        let inserted = entry.insert(Arc::new(Mutex::new(())));
+        Arc::clone(&inserted)
+      },
+    };
     let _guard = lock.lock().await;
     let _cleanup = InflightGuard {
       map: &self.inner.inflight,
@@ -169,6 +207,7 @@ impl Router {
 
     let result = self.race(store_hash, candidates).await;
     if matches!(result, Err(RouterError::NotFound)) {
+      self.inner.miss_lru.insert(store_hash.to_string(), ()).await;
       let _ = self
         .inner
         .db
@@ -216,12 +255,31 @@ impl Router {
     if candidates.is_empty() {
       return Err(RouterError::NoCandidates(store_hash.to_string()));
     }
+    let wait_start = Instant::now();
+    let _race_permit = self
+      .inner
+      .race_semaphore
+      .clone()
+      .acquire_owned()
+      .await
+      .map_err(|_| RouterError::UpstreamUnavailable)?;
+    ncro_metrics::get()
+      .narinfo_race_wait_seconds
+      .with_label_values(&["global"])
+      .observe(wait_start.elapsed().as_secs_f64());
+
+    let filtered = self.cooldown_filtered_candidates(candidates);
+    let effective_candidates = if filtered.is_empty() {
+      candidates.to_vec()
+    } else {
+      filtered
+    };
 
     // Group candidates by priority. Lower number meanshigher priority, tried
     // first. Upstreams whose health entry is missing get i32::MAX so that they
     // fall into the lowest-priority group rather than being silently dropped.
     let mut groups: BTreeMap<i32, Vec<String>> = BTreeMap::new();
-    for url in candidates {
+    for url in &effective_candidates {
       let priority = self
         .inner
         .prober
@@ -232,15 +290,32 @@ impl Router {
     }
 
     let mut any_not_found = false;
+    let mut attempts_total = 0_u64;
     for (_priority, group) in groups {
-      match self.race_group(store_hash, &group).await {
-        Ok(winner) => return self.commit_winner(winner, store_hash).await,
+      let (group_result, attempts) = self.race_group(store_hash, &group).await;
+      attempts_total += attempts;
+      match group_result {
+        Ok(winner) => {
+          ncro_metrics::get()
+            .narinfo_upstream_attempts_per_resolve
+            .with_label_values(&["success"])
+            .observe(attempts_total as f64);
+          return self.commit_winner(winner, store_hash).await;
+        },
         Err(RaceGroupError::NotFound) => any_not_found = true,
         // Try the next priority group on network error; those upstreams were
         // unreachable so we cannot conclude the path is absent.
         Err(RaceGroupError::NetworkError | RaceGroupError::Timeout) => {},
       }
     }
+    ncro_metrics::get()
+      .narinfo_upstream_attempts_per_resolve
+      .with_label_values(&[if any_not_found {
+        "not_found"
+      } else {
+        "unavailable"
+      }])
+      .observe(attempts_total as f64);
 
     if any_not_found {
       Err(RouterError::NotFound)
@@ -255,13 +330,17 @@ impl Router {
     &self,
     store_hash: &str,
     group: &[String],
-  ) -> Result<RaceResult, RaceGroupError> {
+  ) -> (Result<RaceResult, RaceGroupError>, u64) {
     let mut handles = FuturesUnordered::new();
     for upstream in group {
       let upstream = upstream.clone();
       let store_hash = store_hash.to_string();
       let client = self.inner.client.clone();
+      let gate = self.upstream_gate(&upstream);
       handles.push(tokio::spawn(async move {
+        let Ok(_permit) = gate.acquire_owned().await else {
+          return RaceAttempt::NetworkError { upstream };
+        };
         let start = Instant::now();
         let res = client
           .head(format!("{upstream}/{store_hash}.narinfo"))
@@ -269,19 +348,20 @@ impl Router {
           .await;
         match res {
           Ok(resp) if resp.status().is_success() => {
-            Ok(RaceResult {
+            RaceAttempt::Winner(RaceResult {
               url:        upstream,
               latency_ms: start.elapsed().as_secs_f64() * 1000.0,
             })
           },
-          Ok(_) => Err(false), // 404 / non-success = not found
-          Err(_) => Err(true), // network error
+          Ok(_) => RaceAttempt::NotFound, // 404 / non-success = not found
+          Err(_) => RaceAttempt::NetworkError { upstream }, // network error
         }
       }));
     }
 
     let mut net_errs = 0usize;
     let mut not_founds = 0usize;
+    let mut attempts = 0_u64;
     let deadline = tokio::time::sleep(self.inner.race_timeout);
     tokio::pin!(deadline);
 
@@ -293,9 +373,27 @@ impl Router {
           () = &mut deadline => break None,
           joined = handles.next() => {
               match joined {
-                  Some(Ok(Ok(res))) => break Some(res),
-                  Some(Ok(Err(true)) | Err(_)) => net_errs += 1,
-                  Some(Ok(Err(false))) => not_founds += 1,
+                  Some(Ok(RaceAttempt::Winner(res))) => {
+                      attempts += 1;
+                      ncro_metrics::get().narinfo_upstream_attempts.inc();
+                      break Some(res)
+                  },
+                  Some(Ok(RaceAttempt::NetworkError { upstream })) => {
+                      attempts += 1;
+                      ncro_metrics::get().narinfo_upstream_attempts.inc();
+                      net_errs += 1;
+                      self.mark_cooldown(&upstream);
+                  },
+                  Some(Ok(RaceAttempt::NotFound)) => {
+                      attempts += 1;
+                      ncro_metrics::get().narinfo_upstream_attempts.inc();
+                      not_founds += 1;
+                  },
+                  Some(Err(_)) => {
+                      attempts += 1;
+                      ncro_metrics::get().narinfo_upstream_attempts.inc();
+                      net_errs += 1;
+                  },
                   None => break None,
               }
           }
@@ -303,17 +401,53 @@ impl Router {
     };
 
     if let Some(winner) = winner {
-      return Ok(winner);
+      return (Ok(winner), attempts);
     }
 
     // If there is no winner classify the failure so the caller can decide
     // whether to try the next priority group.
     if net_errs > 0 && not_founds == 0 {
-      Err(RaceGroupError::NetworkError)
+      (Err(RaceGroupError::NetworkError), attempts)
     } else if not_founds > 0 {
-      Err(RaceGroupError::NotFound)
+      (Err(RaceGroupError::NotFound), attempts)
     } else {
-      Err(RaceGroupError::Timeout)
+      (Err(RaceGroupError::Timeout), attempts)
+    }
+  }
+
+  fn cooldown_filtered_candidates(&self, candidates: &[String]) -> Vec<String> {
+    candidates
+      .iter()
+      .filter(|url| !self.in_cooldown(url))
+      .cloned()
+      .collect()
+  }
+
+  fn in_cooldown(&self, url: &str) -> bool {
+    if let Some(until) = self.inner.upstream_cooldown.get(url) {
+      if *until > Instant::now() {
+        return true;
+      }
+    }
+    self.inner.upstream_cooldown.remove(url);
+    false
+  }
+
+  fn mark_cooldown(&self, url: &str) {
+    self.inner.upstream_cooldown.insert(
+      url.to_string(),
+      Instant::now() + self.inner.upstream_cooldown_window,
+    );
+  }
+
+  fn upstream_gate(&self, upstream: &str) -> Arc<Semaphore> {
+    match self.inner.upstream_semaphores.entry(upstream.to_string()) {
+      Entry::Occupied(entry) => Arc::clone(entry.get()),
+      Entry::Vacant(entry) => {
+        Arc::clone(&entry.insert(Arc::new(Semaphore::new(
+          usize::try_from(self.inner.per_upstream_limit).unwrap_or(8),
+        ))))
+      },
     }
   }
 

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -555,18 +555,32 @@ impl Router {
 
 #[cfg(test)]
 mod tests {
-  use std::sync::Arc;
+  #![expect(clippy::unwrap_used, reason = "Fine in tests")]
+  use std::{sync::Arc, time::Duration};
 
+  use ncro_db::Db;
+  use ncro_health::Prober;
   use tokio::sync::Mutex;
 
-  use super::InflightGuard;
+  use super::{InflightGuard, Router, RouterTuning};
 
-  #[test]
-  fn inflight_uses_dashmap() {
-    use dashmap::DashMap;
-    // Compile-time check that DashMap is in scope for router.
-    let _: DashMap<String, std::sync::Arc<tokio::sync::Mutex<()>>> =
-      DashMap::new();
+  async fn make_router(cooldown: Duration) -> Router {
+    let db = Db::open(":memory:", 100).await.unwrap();
+    let prober = Prober::new(0.3).unwrap();
+    Router::new(
+      db,
+      prober,
+      Duration::from_secs(3600),
+      Duration::from_secs(5),
+      Duration::from_secs(600),
+      RouterTuning {
+        max_concurrent_races:      4,
+        per_upstream_max_inflight: 2,
+        in_memory_negative_ttl:    Duration::from_secs(300),
+        upstream_cooldown:         cooldown,
+      },
+    )
+    .unwrap()
   }
 
   #[test]
@@ -588,5 +602,67 @@ mod tests {
       !map.contains_key(&key),
       "entry not removed after guard drop"
     );
+  }
+
+  #[tokio::test]
+  async fn mark_cooldown_makes_upstream_unavailable() {
+    let router = make_router(Duration::from_secs(60)).await;
+    let url = "https://cache.example.com";
+    assert!(!router.in_cooldown(url));
+    router.mark_cooldown(url);
+    assert!(router.in_cooldown(url));
+  }
+
+  #[tokio::test]
+  async fn cooldown_expires_with_zero_window() {
+    let router = make_router(Duration::ZERO).await;
+    let url = "https://cache.example.com";
+    // Deadline is Instant::now() + 0, already not in the future.
+    router.mark_cooldown(url);
+    assert!(!router.in_cooldown(url));
+  }
+
+  #[tokio::test]
+  async fn cooldown_filter_excludes_cooled_down_upstream() {
+    let router = make_router(Duration::from_secs(60)).await;
+    let hot = "https://hot.example.com".to_string();
+    let cold = "https://cold.example.com".to_string();
+    router.mark_cooldown(&cold);
+    let result = router.cooldown_filtered_candidates(&[hot.clone(), cold]);
+    assert_eq!(result, vec![hot]);
+  }
+
+  #[tokio::test]
+  async fn cooldown_filter_passes_all_when_none_cooled() {
+    let router = make_router(Duration::from_secs(60)).await;
+    let candidates = vec![
+      "https://a.example.com".to_string(),
+      "https://b.example.com".to_string(),
+    ];
+    assert_eq!(router.cooldown_filtered_candidates(&candidates), candidates);
+  }
+
+  #[tokio::test]
+  async fn upstream_gate_is_stable_per_key() {
+    let router = make_router(Duration::from_secs(60)).await;
+    let url = "https://cache.example.com";
+    let gate1 = router.upstream_gate(url);
+    let gate2 = router.upstream_gate(url);
+    assert!(Arc::ptr_eq(&gate1, &gate2));
+  }
+
+  #[tokio::test]
+  async fn upstream_gate_is_distinct_per_upstream() {
+    let router = make_router(Duration::from_secs(60)).await;
+    let gate_a = router.upstream_gate("https://a.example.com");
+    let gate_b = router.upstream_gate("https://b.example.com");
+    assert!(!Arc::ptr_eq(&gate_a, &gate_b));
+  }
+
+  #[tokio::test]
+  async fn upstream_gate_semaphore_capacity_matches_tuning() {
+    let router = make_router(Duration::from_secs(60)).await;
+    let gate = router.upstream_gate("https://cache.example.com");
+    assert_eq!(gate.available_permits(), 2);
   }
 }

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -463,7 +463,13 @@ impl Router {
   ) -> Result<ResolveResult, RouterError> {
     let (body, raw_nar_url, nar_hash, nar_size) =
       self.fetch_narinfo(&winner.url, store_hash).await?;
-    let nar_url = raw_nar_url.trim_start_matches('/').to_string();
+    // Strip leading slash and query string (harmonia appends ?hash=STORE_HASH)
+    // so the DB key is just the path component for consistent lookups.
+    let nar_url = raw_nar_url
+      .trim_start_matches('/')
+      .split_once('?')
+      .map_or(raw_nar_url.trim_start_matches('/'), |(path, _)| path)
+      .to_string();
 
     ncro_metrics::get()
       .upstream_race_wins

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -256,7 +256,7 @@ async fn try_nar_upstream(
     upstream_request(client, method, headers, format!("{upstream}{path}"))
       .await
       .ok()?;
-  if resp.status() == reqwest::StatusCode::NOT_FOUND {
+  if !resp.status().is_success() {
     return None;
   }
   Some(response_from_reqwest(resp))

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -187,7 +187,18 @@ async fn nar(
   req: Request<Body>,
 ) -> Response {
   ncro_metrics::get().nar_requests.inc();
+  // Path without leading slash for DB lookup (query stripped; harmonia appends
+  // ?hash=STORE_HASH which is not part of the stored key).
   let nar_url = req.uri().path().trim_start_matches('/').to_string();
+  // Full path+query forwarded to upstream so harmonia can locate the store
+  // path.
+  let path_and_query = req
+    .uri()
+    .path_and_query()
+    .map(|pq| pq.as_str())
+    .unwrap_or_else(|| req.uri().path())
+    .to_string();
+
   if let Ok(Some(entry)) = state.db.get_route_by_nar_url(&nar_url).await
     && entry.is_valid()
     && let Some(resp) = try_nar_upstream(
@@ -195,7 +206,7 @@ async fn nar(
       req.method().clone(),
       req.headers(),
       &entry.upstream_url,
-      req.uri().path(),
+      &path_and_query,
     )
     .await
   {
@@ -218,7 +229,7 @@ async fn nar(
         req.method().clone(),
         req.headers(),
         &h.url,
-        req.uri().path(),
+        &path_and_query,
       )
       .await
       {

--- a/ncro/src/cli.rs
+++ b/ncro/src/cli.rs
@@ -3,7 +3,7 @@ use ncro_config::Config;
 use ncro_db::Db;
 use ncro_discovery::Discovery;
 use ncro_health::Prober;
-use ncro_router::Router;
+use ncro_router::{Router, RouterTuning};
 use tokio::net::TcpListener;
 use tracing_subscriber::{EnvFilter, fmt};
 
@@ -65,6 +65,12 @@ pub async fn run() -> anyhow::Result<()> {
     cfg.cache.ttl.0,
     std::time::Duration::from_secs(5),
     cfg.cache.negative_ttl.0,
+    RouterTuning {
+      max_concurrent_races:      cfg.cache.mass_query.max_concurrent_races,
+      per_upstream_max_inflight: cfg.cache.mass_query.per_upstream_max_inflight,
+      in_memory_negative_ttl:    cfg.cache.mass_query.in_memory_negative_ttl.0,
+      upstream_cooldown:         cfg.cache.mass_query.upstream_cooldown.0,
+    },
   )?;
   for upstream in &cfg.upstreams {
     if !upstream.public_key.is_empty() {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -2,6 +2,7 @@
   lib,
   rustPlatform,
   pkg-config,
+  cacert,
 }: let
   cargoTOML = (lib.importTOML ../Cargo.toml).workspace.package;
 in
@@ -23,11 +24,12 @@ in
         ];
       };
 
-    # relies on CA certificates
-    checkFlags = ["--skip=ncro::tests::ema_and_status_progression"];
-
     cargoLock.lockFile = "${finalAttrs.src}/Cargo.lock";
-    nativeBuildInputs = [pkg-config];
+    nativeBuildInputs = [pkg-config cacert];
+
+    # reqwest (rustls) needs a CA bundle to construct a TLS client, even in
+    # tests that never make network requests.
+    env.SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
     meta = {
       homepage = "https://github.com/feel-co/ncro";

--- a/nix/tests/p2p.nix
+++ b/nix/tests/p2p.nix
@@ -331,11 +331,27 @@ in
               assert "/nix/store" in out, \
                   f"{node.name}: /nix-cache-info has wrong StoreDir: {out!r}"
 
-          # /health must return JSON with a 'status' field.
+          # /health must return JSON with a 'status' field and a non-empty
+          # upstreams list where each entry carries url and status.
           for node in (node1, node2, node3):
               h = ncro_health(node)
               assert "status" in h, \
                   f"{node.name}: /health missing 'status': {h!r}"
+              assert "upstreams" in h, \
+                  f"{node.name}: /health missing 'upstreams': {h!r}"
+              assert len(h["upstreams"]) > 0, \
+                  f"{node.name}: /health upstreams list is empty"
+              for up in h["upstreams"]:
+                  assert "url" in up and "status" in up, \
+                      f"{node.name}: upstream entry missing fields: {up!r}"
+
+          # /metrics must return Prometheus-format text (at least one TYPE line).
+          # XXX: This test is rather useless, but I don't want to verify the entire
+          # thing. Maybe in the future?
+          for node in (node1, node2, node3):
+              metrics_out = node.succeed("curl -sf http://localhost:8080/metrics")
+              assert "# TYPE" in metrics_out, \
+                  f"{node.name}: /metrics not in Prometheus format: {metrics_out[:200]!r}"
 
       with subtest("read the runtime-generated public key from node1"):
           # The key was generated at boot; verify it has the expected format.


### PR DESCRIPTION
Adds tuning "mass query" (narinfo race) behavior in the router, corresponding metrics, and short-lived in-memory negative caching for narinfo misses. narinfo lookups should now be a bit more effcient (and observable) while allowing for fine-grained tuning of router concurrency (and, consequently, caching behaviour.) Tiny hit on CPU & I/O but negligible in the grand scheme of things.