### PR TITLE
server: implement S3 upstream handling; authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,20 @@ priority = 10 # lower = preferred on latency ties (within 10%)
 url = "https://nix-community.cachix.org"
 priority = 20
 
+# S3-compatible cache (MinIO, Garage, etc.)
+[[upstreams]]
+url      = "s3://my-bucket?endpoint=minio.example.com&scheme=https"
+priority = 15
+username = "access-key-id"
+password = "secret-access-key"
+
+# Private HTTP cache requiring Basic Auth
+[[upstreams]]
+url      = "https://cache.internal.example.com"
+priority = 5
+username = "ncro"
+password = "hunter2" # it says ******* on my screen it's secure!
+
 [cache]
 db_path = "/var/lib/ncro/routes.db"
 max_entries = 100000 # LRU eviction above this
@@ -203,6 +217,62 @@ gossip_interval = "30s"
 
 Environment overrides are useful for containerized or Systemd deployments where
 you want a fixed config file but still need to tweak one or two settings.
+
+### S3 Upstreams
+
+ncro accepts Nix-style `s3://` URLs in the `url` field and translates them to
+their HTTP(S) equivalent at startup. The rest of the system sees a plain HTTP
+URL. No special runtime path is needed.
+
+Supported query parameters:
+
+<!--markdownlint-disable MD013-->
+
+| Parameter  | Description                                                                                                                         |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `endpoint` | Custom S3-compatible host (MinIO, Garage, Backblaze, …). When set, path-based addressing is used: `{scheme}://{endpoint}/{bucket}`. |
+| `scheme`   | `http` or `https`. Only meaningful with `endpoint`. Default: `https`.                                                               |
+| `region`   | AWS region. Produces virtual-hosted endpoint `{bucket}.s3.{region}.amazonaws.com`.                                                  |
+| `profile`  | AWS credential profile. Accepted but currently ignored; unauthenticated or `username`/`password`-based auth should be used instead. |
+
+<!--markdownlint-enable MD013-->
+
+```toml
+# S3-compatible store with a custom endpoint
+[[upstreams]]
+url      = "s3://my-bucket?endpoint=minio.example.com&scheme=https"
+priority = 15
+username = "access-key-id"
+password = "secret-access-key"
+
+# AWS S3 bucket with explicit region (public or IAM-anonymous)
+[[upstreams]]
+url      = "s3://my-nix-cache?region=eu-west-1"
+priority = 20
+```
+
+> [!NOTE]
+> Authenticated AWS requests using SigV4 (i.e. `profile=`) are not yet
+> supported. For private S3-compatible stores, use `username`/`password` with
+> HTTP Basic Auth. For AWS S3, make the bucket publicly readable or use a
+> pre-signed URL proxy in front of ncro.
+
+### Upstream Authentication
+
+Any upstream can carry `username` and `password` fields. ncro itself sends HTTP
+Basic Auth on every request to that upstream: health probes, narinfo races, and
+NAR streaming.
+
+```toml
+[[upstreams]]
+url      = "https://cache.internal.example.com"
+priority = 5
+username = "ncro"
+password = "hunter2"
+```
+
+`password` is optional. Omit it for token-only schemes where the token goes in
+the username field.
 
 ## NixOS Integration
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -23,6 +23,7 @@ pub enum ConfigError {
 /// - `scheme`   - `http` or `https` (default `https`; only relevant with
 ///   `endpoint`)
 /// - `region`   - AWS region; used to build the virtual-hosted AWS endpoint
+/// - `addressing-style` - `auto`, `path`, or `virtual`
 /// - `profile`  - credential profile (auth not yet supported; parameter
 ///   ignored)
 ///
@@ -42,28 +43,49 @@ fn s3_url_to_http(raw: &str) -> Result<String, ConfigError> {
   let mut endpoint: Option<String> = None;
   let mut scheme = "https".to_string();
   let mut region: Option<String> = None;
+  let mut addressing_style = "auto".to_string();
 
   for (key, value) in parsed.query_pairs() {
     match key.as_ref() {
       "endpoint" => endpoint = Some(value.into_owned()),
       "scheme" => scheme = value.into_owned(),
       "region" => region = Some(value.into_owned()),
+      "addressing-style" => addressing_style = value.into_owned(),
       _ => {},
     }
   }
 
-  Ok(endpoint.map_or_else(
-    || {
-      region.map_or_else(
+  match (endpoint, addressing_style.as_str()) {
+    (Some(ep), "virtual") => Ok(format!("{scheme}://{bucket}.{ep}")),
+    (Some(ep), "auto" | "path") => Ok(format!("{scheme}://{ep}/{bucket}")),
+    (None, "path") => {
+      let host = region.map_or_else(
+        || "s3.amazonaws.com".to_string(),
+        |r| format!("s3.{r}.amazonaws.com"),
+      );
+      Ok(format!("https://{host}/{bucket}"))
+    },
+    (None, "auto") if bucket.contains('.') => {
+      let host = region.map_or_else(
+        || "s3.amazonaws.com".to_string(),
+        |r| format!("s3.{r}.amazonaws.com"),
+      );
+      Ok(format!("https://{host}/{bucket}"))
+    },
+    (None, "auto" | "virtual") => {
+      Ok(region.map_or_else(
         // AWS S3 without region: region-agnostic global endpoint.
         || format!("https://{bucket}.s3.amazonaws.com"),
         // AWS S3 with known region: virtual-hosted-style endpoint.
         |r| format!("https://{bucket}.s3.{r}.amazonaws.com"),
-      )
+      ))
     },
-    // S3-compatible store with explicit host: use path-based addressing.
-    |ep| format!("{scheme}://{ep}/{bucket}"),
-  ))
+    (_, other) => {
+      Err(ConfigError::Validation(format!(
+        "s3 upstream {raw:?}: unsupported addressing-style {other:?}"
+      )))
+    },
+  }
 }
 
 #[cfg(test)]
@@ -109,6 +131,42 @@ mod tests {
       "https://minio.example.com/my-cache"
     );
     Ok(())
+  }
+
+  #[test]
+  fn s3_url_custom_endpoint_virtual_addressing() -> Result<(), ConfigError> {
+    assert_eq!(
+      s3_url_to_http(
+        "s3://my-cache?endpoint=minio.example.com&addressing-style=virtual"
+      )?,
+      "https://my-cache.minio.example.com"
+    );
+    Ok(())
+  }
+
+  #[test]
+  fn s3_url_aws_path_addressing() -> Result<(), ConfigError> {
+    assert_eq!(
+      s3_url_to_http("s3://my-cache?region=eu-west-1&addressing-style=path")?,
+      "https://s3.eu-west-1.amazonaws.com/my-cache"
+    );
+    Ok(())
+  }
+
+  #[test]
+  fn s3_url_aws_auto_uses_path_for_dotted_bucket() -> Result<(), ConfigError> {
+    assert_eq!(
+      s3_url_to_http("s3://my.cache?region=eu-west-1")?,
+      "https://s3.eu-west-1.amazonaws.com/my.cache"
+    );
+    Ok(())
+  }
+
+  #[test]
+  fn s3_url_rejects_unknown_addressing_style() {
+    assert!(
+      s3_url_to_http("s3://my-cache?addressing-style=unsupported").is_err()
+    );
   }
 
   #[test]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -193,6 +193,8 @@ pub struct UpstreamConfig {
   pub url:        String,
   pub priority:   i32,
   pub public_key: String,
+  pub username:   String,
+  pub password:   Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -361,9 +363,10 @@ impl Default for Config {
     Self {
       server:    ServerConfig::default(),
       upstreams: vec![UpstreamConfig {
-        url:        "https://cache.nixos.org".to_string(),
-        priority:   10,
+        url: "https://cache.nixos.org".to_string(),
+        priority: 10,
         public_key: String::new(),
+        ..Default::default()
       }],
       cache:     CacheConfig::default(),
       mesh:      MeshConfig::default(),

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -14,6 +14,58 @@ pub enum ConfigError {
   Validation(String),
 }
 
+/// Converts a Nix-style `s3://bucket?...` URL to the equivalent HTTP(S) URL
+/// that ncro's HTTP client can use.
+///
+/// Supported query parameters (all optional):
+///
+/// - `endpoint` - custom S3-compatible host; selects path-based addressing
+/// - `scheme`   - `http` or `https` (default `https`; only relevant with
+///   `endpoint`)
+/// - `region`   - AWS region; used to build the virtual-hosted AWS endpoint
+/// - `profile`  - credential profile (auth not yet supported; parameter
+///   ignored)
+///
+/// # Errors
+///
+/// Returns [`ConfigError::Validation`] if the URL cannot be parsed or is
+/// missing a bucket name, i.e., host component.
+fn s3_url_to_http(raw: &str) -> Result<String, ConfigError> {
+  let parsed = Url::parse(raw).map_err(|e| {
+    ConfigError::Validation(format!("s3 upstream: invalid URL {raw:?}: {e}"))
+  })?;
+
+  let bucket = parsed.host_str().ok_or_else(|| {
+    ConfigError::Validation(format!("s3 upstream {raw:?}: missing bucket name"))
+  })?;
+
+  let mut endpoint: Option<String> = None;
+  let mut scheme = "https".to_string();
+  let mut region: Option<String> = None;
+
+  for (key, value) in parsed.query_pairs() {
+    match key.as_ref() {
+      "endpoint" => endpoint = Some(value.into_owned()),
+      "scheme" => scheme = value.into_owned(),
+      "region" => region = Some(value.into_owned()),
+      _ => {},
+    }
+  }
+
+  Ok(endpoint.map_or_else(
+    || {
+      region.map_or_else(
+        // AWS S3 without region: region-agnostic global endpoint.
+        || format!("https://{bucket}.s3.amazonaws.com"),
+        // AWS S3 with known region: virtual-hosted-style endpoint.
+        |r| format!("https://{bucket}.s3.{r}.amazonaws.com"),
+      )
+    },
+    // S3-compatible store with explicit host: use path-based addressing.
+    |ep| format!("{scheme}://{ep}/{bucket}"),
+  ))
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -35,6 +87,65 @@ mod tests {
     )?;
     assert_eq!(cfg.server.cache_priority, 40);
     assert_eq!(cfg.cache.ttl.0, Duration::from_secs(7200));
+    Ok(())
+  }
+
+  #[test]
+  fn s3_url_custom_endpoint_http() -> Result<(), ConfigError> {
+    assert_eq!(
+      s3_url_to_http(
+        "s3://my-cache?profile=default&scheme=http&region=us-east-1&\
+         endpoint=minio.example.com",
+      )?,
+      "http://minio.example.com/my-cache"
+    );
+    Ok(())
+  }
+
+  #[test]
+  fn s3_url_custom_endpoint_default_scheme() -> Result<(), ConfigError> {
+    assert_eq!(
+      s3_url_to_http("s3://my-cache?endpoint=minio.example.com")?,
+      "https://minio.example.com/my-cache"
+    );
+    Ok(())
+  }
+
+  #[test]
+  fn s3_url_aws_with_region() -> Result<(), ConfigError> {
+    assert_eq!(
+      s3_url_to_http("s3://my-cache?region=eu-west-1")?,
+      "https://my-cache.s3.eu-west-1.amazonaws.com"
+    );
+    Ok(())
+  }
+
+  #[test]
+  fn s3_url_aws_no_params() -> Result<(), ConfigError> {
+    assert_eq!(
+      s3_url_to_http("s3://my-cache")?,
+      "https://my-cache.s3.amazonaws.com"
+    );
+    Ok(())
+  }
+
+  #[test]
+  fn s3_url_missing_bucket_is_error() {
+    assert!(s3_url_to_http("s3://").is_err());
+  }
+
+  #[test]
+  fn load_translates_s3_upstream() -> Result<(), ConfigError> {
+    let toml = r#"
+[[upstreams]]
+url = "s3://dcr-nix-cache?profile=default&scheme=http&region=us-east-1&endpoint=s3.example.com"
+priority = 10
+"#;
+    let cfg: Config = toml::from_str(toml)?;
+    assert_eq!(
+      s3_url_to_http(&cfg.upstreams[0].url)?,
+      "http://s3.example.com/dcr-nix-cache"
+    );
     Ok(())
   }
 
@@ -289,6 +400,12 @@ impl Config {
       && !v.is_empty()
     {
       cfg.logging.level = v;
+    }
+
+    for upstream in &mut cfg.upstreams {
+      if upstream.url.starts_with("s3://") {
+        upstream.url = s3_url_to_http(&upstream.url)?;
+      }
     }
 
     Ok(cfg)

--- a/crates/health/src/lib.rs
+++ b/crates/health/src/lib.rs
@@ -80,6 +80,7 @@ pub struct Prober {
 struct ProberInner {
   alpha:          f64,
   table:          RwLock<HashMap<String, UpstreamHealth>>,
+  auth:           RwLock<HashMap<String, (String, Option<String>)>>,
   client:         reqwest::Client,
   persist_health: RwLock<Option<PersistHealth>>,
 }
@@ -95,6 +96,7 @@ impl Prober {
       inner: Arc::new(ProberInner {
         alpha,
         table: RwLock::new(HashMap::new()),
+        auth: RwLock::new(HashMap::new()),
         client: reqwest::Client::builder()
           .timeout(Duration::from_secs(10))
           .build()?,
@@ -109,11 +111,23 @@ impl Prober {
   }
 
   pub async fn init_upstreams(&self, upstreams: &[UpstreamConfig]) {
-    let mut table = self.inner.table.write().await;
-    for upstream in upstreams {
-      table.entry(upstream.url.clone()).or_insert_with(|| {
-        UpstreamHealth::new(upstream.url.clone(), upstream.priority)
-      });
+    {
+      let mut table = self.inner.table.write().await;
+      for upstream in upstreams {
+        table.entry(upstream.url.clone()).or_insert_with(|| {
+          UpstreamHealth::new(upstream.url.clone(), upstream.priority)
+        });
+      }
+    }
+    {
+      let mut auth = self.inner.auth.write().await;
+      for upstream in upstreams {
+        if !upstream.username.is_empty() {
+          auth.entry(upstream.url.clone()).or_insert_with(|| {
+            (upstream.username.clone(), upstream.password.clone())
+          });
+        }
+      }
     }
   }
 
@@ -241,11 +255,13 @@ impl Prober {
     if !self.inner.table.read().await.contains_key(&url) {
       return;
     }
+    let auth = self.inner.auth.read().await.get(&url).cloned();
     let start = Instant::now();
-    let ok = self
-      .inner
-      .client
-      .head(format!("{url}/nix-cache-info"))
+    let mut req = self.inner.client.head(format!("{url}/nix-cache-info"));
+    if let Some((user, pass)) = auth {
+      req = req.basic_auth(user, pass);
+    }
+    let ok = req
       .send()
       .await
       .map(|resp| resp.status().as_u16() == 200)
@@ -427,14 +443,16 @@ mod tests {
     let p = Prober::new(0.3)?;
     p.init_upstreams(&[
       UpstreamConfig {
-        url:        "https://fast.com".into(),
-        priority:   1,
+        url: "https://fast.com".into(),
+        priority: 1,
         public_key: String::new(),
+        ..Default::default()
       },
       UpstreamConfig {
-        url:        "https://down.com".into(),
-        priority:   1,
+        url: "https://down.com".into(),
+        priority: 1,
         public_key: String::new(),
+        ..Default::default()
       },
     ])
     .await;
@@ -453,14 +471,16 @@ mod tests {
     let p = Prober::new(0.3)?;
     p.init_upstreams(&[
       UpstreamConfig {
-        url:        "https://high-priority.com".into(),
-        priority:   1,
+        url: "https://high-priority.com".into(),
+        priority: 1,
         public_key: String::new(),
+        ..Default::default()
       },
       UpstreamConfig {
-        url:        "https://low-priority.com".into(),
-        priority:   10,
+        url: "https://low-priority.com".into(),
+        priority: 10,
         public_key: String::new(),
+        ..Default::default()
       },
     ])
     .await;

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -61,6 +61,7 @@ struct RouterInner {
   negative_ttl:             Duration,
   client:                   reqwest::Client,
   upstream_keys:            RwLock<HashMap<String, String>>,
+  upstream_auth:            RwLock<HashMap<String, (String, Option<String>)>>,
   inflight:                 DashMap<String, Arc<Mutex<()>>>,
   lru:                      MokaCache<String, Arc<ResolveResult>>,
   miss_lru:                 MokaCache<String, ()>,
@@ -133,6 +134,7 @@ impl Router {
         negative_ttl,
         client: reqwest::Client::builder().timeout(race_timeout).build()?,
         upstream_keys: RwLock::new(HashMap::new()),
+        upstream_auth: RwLock::new(HashMap::new()),
         inflight: DashMap::new(),
         lru: MokaCache::builder()
           .max_capacity(1024)
@@ -170,6 +172,21 @@ impl Router {
       .await
       .insert(url, public_key);
     Ok(())
+  }
+
+  /// Register HTTP Basic Auth credentials for an upstream URL.
+  pub async fn set_upstream_auth(
+    &self,
+    url: String,
+    username: String,
+    password: Option<String>,
+  ) {
+    self
+      .inner
+      .upstream_auth
+      .write()
+      .await
+      .insert(url, (username, password));
   }
 
   /// Resolve a narinfo hash to an upstream URL by checking the route cache
@@ -340,21 +357,24 @@ impl Router {
     store_hash: &str,
     group: &[String],
   ) -> (Result<RaceResult, RaceGroupError>, u32) {
+    let auth_snapshot = self.inner.upstream_auth.read().await.clone();
     let mut handles = FuturesUnordered::new();
     for upstream in group {
       let upstream = upstream.clone();
       let store_hash = store_hash.to_string();
       let client = self.inner.client.clone();
       let gate = self.upstream_gate(&upstream);
+      let auth = auth_snapshot.get(&upstream).cloned();
       handles.push(tokio::spawn(async move {
         let Ok(_permit) = gate.acquire_owned().await else {
           return RaceAttempt::NetworkError { upstream };
         };
         let start = Instant::now();
-        let res = client
-          .head(format!("{upstream}/{store_hash}.narinfo"))
-          .send()
-          .await;
+        let mut req = client.head(format!("{upstream}/{store_hash}.narinfo"));
+        if let Some((user, pass)) = auth {
+          req = req.basic_auth(user, pass);
+        }
+        let res = req.send().await;
         match res {
           Ok(resp) if resp.status().is_success() => {
             RaceAttempt::Winner(RaceResult {
@@ -543,12 +563,15 @@ impl Router {
     upstream: &str,
     store_hash: &str,
   ) -> Result<(Option<Vec<u8>>, String, String, u64), RouterError> {
-    let resp = self
+    let auth = self.inner.upstream_auth.read().await.get(upstream).cloned();
+    let mut req = self
       .inner
       .client
-      .get(format!("{upstream}/{store_hash}.narinfo"))
-      .send()
-      .await?;
+      .get(format!("{upstream}/{store_hash}.narinfo"));
+    if let Some((user, pass)) = auth {
+      req = req.basic_auth(user, pass);
+    }
+    let resp = req.send().await?;
     if !resp.status().is_success() {
       return Err(RouterError::NotFound);
     }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -161,6 +161,7 @@ async fn narinfo(
         req.method().clone(),
         req.headers(),
         format!("{}{}", result.url, req.uri().path()),
+        upstream_auth(&state.upstreams, &result.url),
       )
       .await
     },
@@ -206,6 +207,7 @@ async fn nar(
       req.headers(),
       &entry.upstream_url,
       &path_and_query,
+      upstream_auth(&state.upstreams, &entry.upstream_url),
     )
     .await
   {
@@ -229,6 +231,7 @@ async fn nar(
         req.headers(),
         &h.url,
         &path_and_query,
+        upstream_auth(&state.upstreams, &h.url),
       )
       .await
       {
@@ -237,6 +240,16 @@ async fn nar(
     }
   }
   StatusCode::NOT_FOUND.into_response()
+}
+
+fn upstream_auth(
+  upstreams: &[UpstreamConfig],
+  url: &str,
+) -> Option<(String, Option<String>)> {
+  upstreams
+    .iter()
+    .find(|u| u.url == url && !u.username.is_empty())
+    .map(|u| (u.username.clone(), u.password.clone()))
 }
 
 async fn upstream_urls(state: &AppState) -> Vec<String> {
@@ -261,11 +274,17 @@ async fn try_nar_upstream(
   headers: &HeaderMap,
   upstream: &str,
   path: &str,
+  auth: Option<(String, Option<String>)>,
 ) -> Option<Response> {
-  let resp =
-    upstream_request(client, method, headers, format!("{upstream}{path}"))
-      .await
-      .ok()?;
+  let resp = upstream_request(
+    client,
+    method,
+    headers,
+    format!("{upstream}{path}"),
+    auth,
+  )
+  .await
+  .ok()?;
   if !resp.status().is_success() {
     return None;
   }
@@ -277,8 +296,9 @@ async fn proxy(
   method: Method,
   headers: &HeaderMap,
   url: String,
+  auth: Option<(String, Option<String>)>,
 ) -> Response {
-  match upstream_request(client, method, headers, url).await {
+  match upstream_request(client, method, headers, url, auth).await {
     Ok(resp) => response_from_reqwest(resp),
     Err(err) => {
       tracing::warn!(error = %err, "upstream request failed");
@@ -292,8 +312,12 @@ async fn upstream_request(
   method: Method,
   headers: &HeaderMap,
   url: String,
+  auth: Option<(String, Option<String>)>,
 ) -> reqwest::Result<reqwest::Response> {
   let mut req = client.request(method, url);
+  if let Some((user, pass)) = auth {
+    req = req.basic_auth(user, pass);
+  }
   for name in ["accept", "accept-encoding", "range"] {
     if let Some(value) = headers.get(name) {
       req = req.header(name, value);

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -333,9 +333,12 @@ fn response_from_reqwest(resp: reqwest::Response) -> Response {
   let stream = resp.bytes_stream().map_err(std::io::Error::other);
   let mut out = Response::builder().status(status);
   for name in [
+    "accept-ranges",
     "content-type",
     "content-length",
+    "content-range",
     "content-encoding",
+    "etag",
     "x-nix-signature",
     "cache-control",
     "last-modified",

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,7 @@
     in {
       p2p-discovery = pkgs.callPackage ./nix/tests/p2p.nix {inherit self;};
       e2e = pkgs.callPackage ./nix/tests/e2e.nix {inherit self;};
+      s3 = pkgs.callPackage ./nix/tests/s3.nix {inherit self;};
     });
 
     # Provides the default formatter for 'nix fmt'.

--- a/ncro/src/cli.rs
+++ b/ncro/src/cli.rs
@@ -72,11 +72,21 @@ pub async fn run() -> anyhow::Result<()> {
       upstream_cooldown:         cfg.cache.mass_query.upstream_cooldown.0,
     },
   )?;
+
   for upstream in &cfg.upstreams {
     if !upstream.public_key.is_empty() {
       router
         .set_upstream_key(upstream.url.clone(), upstream.public_key.clone())
         .await?;
+    }
+    if !upstream.username.is_empty() {
+      router
+        .set_upstream_auth(
+          upstream.url.clone(),
+          upstream.username.clone(),
+          upstream.password.clone(),
+        )
+        .await;
     }
   }
 

--- a/nix/tests/s3.nix
+++ b/nix/tests/s3.nix
@@ -1,0 +1,380 @@
+{
+  pkgs,
+  self,
+}: let
+  # Two payloads with distinct content so we can tell which backend served each.
+  s3Payload = pkgs.runCommandLocal "ncro-s3-payload" {} ''
+    mkdir -p "$out"
+    echo "s3 upstream test payload" > "$out/data"
+  '';
+
+  authPayload = pkgs.runCommandLocal "ncro-auth-payload" {} ''
+    mkdir -p "$out"
+    echo "auth upstream test payload" > "$out/data"
+  '';
+
+  # Garage cluster settings.
+  # Those are fixed values for a single-node ephemeral cluster.
+  # XXX: rpc_secret must be 32 bytes, hex-encoded (64 chars).
+  garageRpcSecret = "c8b325ea88a9ad61e58d0ed9ba91fd0db70699e3a30ca2d8a70ee0c4a09ceaf2";
+  garageRegion = "garage";
+  garageBucket = "nix-cache";
+
+  # Credentials for the nginx-protected nix-serve (auth subtest).
+  authUser = "ncro";
+  authPass = "testpassword";
+
+  cacheKeyName = "ncro-s3-test";
+
+  commonBase = {
+    virtualisation.memorySize = 1536;
+    virtualisation.diskSize = 4096;
+    networking.firewall.enable = false;
+    nix.settings.experimental-features = ["nix-command"];
+  };
+in
+  pkgs.testers.runNixOSTest {
+    name = "ncro-s3";
+
+    nodes = {
+      # Runs Garage (S3-compatible object store) pre-populated with s3Payload.
+      # Also runs nix-serve behind nginx with Basic Auth for the auth subtest.
+      # Garage v1.x does not support anonymous S3 API access, so an nginx
+      # location on port 3903 strips the bucket prefix and proxies requests to
+      # Garage's web endpoint (port 3902) which allows anonymous reads via the
+      # virtual-host mechanism after `garage bucket website --allow`.
+      backend = {
+        config,
+        pkgs,
+        lib,
+        ...
+      }: {
+        imports = [commonBase];
+
+        system.extraDependencies = [s3Payload authPayload];
+
+        services.garage = {
+          enable = true;
+          package = pkgs.garage;
+          settings = {
+            rpc_bind_addr = "[::]:3901";
+            rpc_public_addr = "127.0.0.1:3901";
+            rpc_secret = garageRpcSecret;
+            # v1.x single-node mode.
+            replication_mode = "none";
+            s3_api = {
+              s3_region = garageRegion;
+              api_bind_addr = "[::]:3900";
+            };
+            s3_web = {
+              bind_addr = "[::]:3902";
+              root_domain = ".web.garage";
+              index = "index.html";
+            };
+          };
+        };
+
+        environment.systemPackages = [pkgs.garage];
+
+        systemd.services = {
+          # Bootstrap the Garage cluster, upload s3Payload as a Nix binary cache,
+          # and enable anonymous web access for the bucket.
+          setup-garage = {
+            description = "Initialise Garage layout, bucket, and upload Nix store paths";
+            wantedBy = ["multi-user.target"];
+            after = ["garage.service" "nix-daemon.service"];
+            requires = ["garage.service" "nix-daemon.service"];
+            path = [pkgs.garage pkgs.gawk pkgs.coreutils];
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              ExecStart = pkgs.writeShellScript "setup-garage" ''
+                set -euo pipefail
+
+                # Wait until the Garage daemon accepts admin requests.
+                until ${pkgs.garage}/bin/garage status >/dev/null 2>&1; do
+                  sleep 1
+                done
+
+                # Apply a single-node layout (zone dc1, 1 GiB capacity).
+                # Capture full output before filtering to avoid Garage panicking
+                # on SIGPIPE from short-reading consumers like cut/awk.
+                node_fqn=$(${pkgs.garage}/bin/garage node id)
+                node_id=$(printf '%s\n' "$node_fqn" | cut -d@ -f1)
+                ${pkgs.garage}/bin/garage layout assign -z dc1 -c 1G "$node_id"
+                layout_show=$(${pkgs.garage}/bin/garage layout show)
+                version=$(printf '%s\n' "$layout_show" \
+                  | awk '/Current cluster layout version:/{print $NF+1}')
+                ${pkgs.garage}/bin/garage layout apply --version "$version"
+
+                # Create the bucket and enable anonymous reads via the web endpoint.
+                ${pkgs.garage}/bin/garage bucket create ${garageBucket}
+                ${pkgs.garage}/bin/garage bucket website --allow ${garageBucket}
+
+                # Create an access key for nix copy uploads.
+                key_output=$(${pkgs.garage}/bin/garage key create nix-upload)
+                key_id=$(printf '%s\n' "$key_output" | awk '/^Key ID:/{print $3}')
+                key_secret=$(printf '%s\n' "$key_output" | awk '/^Secret key:/{print $3}')
+                ${pkgs.garage}/bin/garage bucket allow \
+                  --read --write ${garageBucket} --key nix-upload
+
+                # Upload the store path as a Nix binary cache.
+                export AWS_ACCESS_KEY_ID=$key_id
+                export AWS_SECRET_ACCESS_KEY=$key_secret
+                export AWS_REGION=${garageRegion}
+                ${config.nix.package}/bin/nix copy \
+                    --to 's3://${garageBucket}?endpoint=127.0.0.1:3900&scheme=http&region=${garageRegion}' \
+                    --no-require-sigs \
+                    "${s3Payload}"
+              '';
+            };
+          };
+
+          gen-cache-key = {
+            description = "Generate Nix binary cache signing key";
+            wantedBy = ["multi-user.target"];
+            before = ["nix-serve.service"];
+            after = ["nix-daemon.service"];
+            requires = ["nix-daemon.service"];
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              ExecStart = pkgs.writeShellScript "gen-cache-key" ''
+                set -euo pipefail
+                mkdir -p /etc/nix
+                if [ ! -f /etc/nix/cache-key.sec ]; then
+                  ${config.nix.package}/bin/nix-store \
+                    --generate-binary-cache-key "${cacheKeyName}" \
+                    /etc/nix/cache-key.sec \
+                    /etc/nix/cache-key.pub
+                fi
+                chmod 644 /etc/nix/cache-key.pub /etc/nix/cache-key.sec
+                ${config.nix.package}/bin/nix store sign \
+                  --key-file /etc/nix/cache-key.sec \
+                  "${authPayload}"
+              '';
+            };
+          };
+
+          nix-serve = {
+            description = "nix-serve binary cache (port 5000, plain HTTP)";
+            wantedBy = ["multi-user.target"];
+            after = ["gen-cache-key.service" "network.target"];
+            requires = ["gen-cache-key.service"];
+            environment.NIX_SECRET_KEY_FILE = "/etc/nix/cache-key.sec";
+            serviceConfig = {
+              ExecStart = "${pkgs.nix-serve}/bin/nix-serve --port 5000";
+              Restart = "on-failure";
+            };
+          };
+        };
+
+        services.nginx = {
+          enable = true;
+          virtualHosts = {
+            # Port 3903: strips /nix-cache/ prefix and proxies to Garage web
+            # endpoint at port 3902.  ncro translates
+            # s3://nix-cache?endpoint=backend:3903 -> http://backend:3903/nix-cache,
+            # so requests arrive as GET /nix-cache/<object>; this rewrite removes
+            # the bucket segment before forwarding to Garage's virtual-host web API.
+            garage-web-adapter = {
+              listen = [
+                {
+                  addr = "0.0.0.0";
+                  port = 3903;
+                }
+              ];
+              locations."~ ^/${garageBucket}/" = {
+                extraConfig = ''
+                  rewrite ^/${garageBucket}/(.+)$ /$1 break;
+                  proxy_pass http://127.0.0.1:3902;
+                  proxy_set_header Host ${garageBucket}.web.garage;
+                '';
+              };
+            };
+
+            # Port 8081 is for Basic Auth proxy to nix-serve for the auth subtest.
+            auth-cache = {
+              listen = [
+                {
+                  addr = "0.0.0.0";
+                  port = 8081;
+                }
+              ];
+              basicAuth = {"${authUser}" = authPass;};
+              locations."/" = {proxyPass = "http://127.0.0.1:5000";};
+            };
+          };
+        };
+      };
+
+      # ncro node with two upstreams:
+      #  1. s3://nix-cache?endpoint=backend:3903&scheme=http  (S3 subtest, served
+      #     through the nginx web-adapter in front of Garage)
+      #  2. http://backend:8081 with username/password         (auth subtest)
+      proxy = {
+        imports = [self.nixosModules.ncro commonBase];
+
+        nix.settings.trusted-substituters = ["http://localhost:8080"];
+
+        services.ncro = {
+          enable = true;
+          settings = {
+            server.listen = ":8080";
+            upstreams = [
+              {
+                url = "s3://${garageBucket}?endpoint=backend:3903&scheme=http";
+                priority = 1;
+              }
+              {
+                url = "http://backend:8081";
+                priority = 2;
+                username = authUser;
+                password = authPass;
+              }
+            ];
+            cache = {
+              ttl = "5m";
+              negative_ttl = "30s";
+            };
+          };
+        };
+      };
+    };
+
+    testScript = ''
+      import json
+
+      def ncro_health(node):
+          out = node.succeed("curl -sf http://localhost:8080/health")
+          return json.loads(out)
+
+      def store_hash(path):
+          # /nix/store/<hash>-<name> -> <hash>
+          return path.split("/")[3].split("-")[0]
+
+      def nar_url_from_narinfo(narinfo):
+          for line in narinfo.splitlines():
+              if line.startswith("URL: "):
+                  return line.split("URL: ", 1)[1]
+          raise AssertionError(f"narinfo missing URL field: {narinfo!r}")
+
+      s3_path   = "${s3Payload}"
+      auth_path = "${authPayload}"
+      s3_hash   = store_hash(s3_path)
+      auth_hash = store_hash(auth_path)
+
+      with subtest("boot all nodes"):
+          start_all()
+
+          backend.wait_for_unit("garage.service")
+          backend.wait_for_open_port(3900)
+          backend.wait_for_unit("setup-garage.service")
+          backend.wait_for_open_port(3902)
+          backend.wait_for_open_port(3903)
+
+          backend.wait_for_unit("gen-cache-key.service")
+          backend.wait_for_unit("nix-serve.service")
+          backend.wait_for_open_port(5000)
+          backend.wait_for_unit("nginx.service")
+          backend.wait_for_open_port(8081)
+
+          proxy.wait_for_unit("ncro.service")
+          proxy.wait_for_open_port(8080)
+
+      with subtest("Garage bucket contains nix-cache-info"):
+          out = backend.succeed(
+              "curl -sf -H 'Host: ${garageBucket}.web.garage' "
+              "http://127.0.0.1:3902/nix-cache-info"
+          )
+          assert "StoreDir" in out, \
+              f"nix-cache-info missing StoreDir: {out!r}"
+
+      with subtest("Garage bucket contains narinfo for s3Payload"):
+          out = backend.succeed(
+              f"curl -sf -H 'Host: ${garageBucket}.web.garage' "
+              f"http://127.0.0.1:3902/{s3_hash}.narinfo"
+          )
+          assert "StorePath" in out, \
+              f"Garage narinfo missing StorePath: {out!r}"
+
+      with subtest("auth backend rejects unauthenticated requests"):
+          backend.fail(
+              f"curl -sf http://127.0.0.1:8081/{auth_hash}.narinfo"
+          )
+
+      with subtest("auth backend accepts requests with correct credentials"):
+          out = backend.succeed(
+              f"curl -sf -u ${authUser}:${authPass} http://127.0.0.1:8081/{auth_hash}.narinfo"
+          )
+          assert "StorePath" in out, \
+              f"auth backend did not serve narinfo with credentials: {out!r}"
+
+      with subtest("ncro health lists both upstreams"):
+          h = ncro_health(proxy)
+          assert "upstreams" in h, f"/health missing upstreams: {h!r}"
+          urls = [u["url"] for u in h["upstreams"]]
+          # The s3:// URL is translated to http://backend:3903/nix-cache at
+          # startup, so the health report uses the translated HTTP URL.
+          assert any("backend:3903" in u for u in urls), \
+              f"S3 upstream (translated) missing from /health: {urls}"
+          assert any("backend:8081" in u for u in urls), \
+              f"auth upstream missing from /health: {urls}"
+
+      with subtest("ncro proxies narinfo from S3 upstream"):
+          out = proxy.succeed(
+              f"curl -sf http://localhost:8080/{s3_hash}.narinfo"
+          )
+          assert "StorePath" in out, \
+              f"ncro did not proxy S3 narinfo: {out!r}"
+
+      with subtest("ncro preserves byte-range responses from S3 NARs"):
+          narinfo = proxy.succeed(
+              f"curl -sf http://localhost:8080/{s3_hash}.narinfo"
+          )
+          nar_url = nar_url_from_narinfo(narinfo)
+          headers = proxy.succeed(
+              "curl -sS -D - -o /dev/null "
+              "-H 'Range: bytes=0-15' "
+              f"http://localhost:8080/{nar_url}"
+          )
+          header_lines = [line.rstrip("\r") for line in headers.splitlines()]
+          lowered = [line.lower() for line in header_lines]
+          assert any(line.startswith("HTTP/") and " 206 " in line for line in header_lines), \
+              f"range request did not return 206 Partial Content: {headers!r}"
+          assert any(line.startswith("content-range: bytes 0-15/") for line in lowered), \
+              f"Content-Range header missing or wrong: {headers!r}"
+          assert "accept-ranges: bytes" in lowered, \
+              f"Accept-Ranges header missing: {headers!r}"
+
+      with subtest("nix copy through ncro from S3 upstream"):
+          proxy.fail(f"nix store ls {s3_path} 2>/dev/null")
+          proxy.succeed(
+              f"nix copy --from http://localhost:8080 --no-require-sigs {s3_path}"
+          )
+          proxy.succeed(f"test -f {s3_path}/data")
+          proxy.succeed(f"grep -q 's3 upstream' {s3_path}/data")
+
+      with subtest("ncro proxies narinfo from authenticated upstream"):
+          out = proxy.succeed(
+              f"curl -sf http://localhost:8080/{auth_hash}.narinfo"
+          )
+          assert "StorePath" in out, \
+              f"ncro did not proxy auth narinfo: {out!r}"
+
+      with subtest("nix copy through ncro from authenticated upstream"):
+          proxy.fail(f"nix store ls {auth_path} 2>/dev/null")
+          proxy.succeed(
+              f"nix copy --from http://localhost:8080 --no-require-sigs {auth_path}"
+          )
+          proxy.succeed(f"test -f {auth_path}/data")
+          proxy.succeed(f"grep -q 'auth upstream' {auth_path}/data")
+
+      with subtest("ncro records cache hits after repeated requests"):
+          proxy.succeed(f"curl -sf http://localhost:8080/{s3_hash}.narinfo > /dev/null")
+          proxy.succeed(f"curl -sf http://localhost:8080/{auth_hash}.narinfo > /dev/null")
+          metrics = proxy.succeed("curl -sf http://localhost:8080/metrics")
+          assert "ncro_narinfo_cache" in metrics, \
+              f"narinfo cache metric not in /metrics: {metrics[:400]!r}"
+    '';
+  }


### PR DESCRIPTION
Fixes #12 

Adds support for S3-compatible upstream caches and HTTP Basic Authentication for upstreams. We do this by parsing and translating `s3://` URLs in configuration. The new config, as a part of authenticated S3 support, allows credentials to be specified per-upstream, and ensures authentication is consistently applied to all upstream HTTP requests. Should make it possible to use both public and private S3-compatible caches and upstreams requiring authentication