### PR TITLE
Add upstream path filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2169,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "ncro"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "ncro-config"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "hex",
  "humantime-serde",
@@ -2202,7 +2202,7 @@ dependencies = [
 
 [[package]]
 name = "ncro-db"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "chrono",
  "serde",
@@ -2213,7 +2213,7 @@ dependencies = [
 
 [[package]]
 name = "ncro-discovery"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "mdns-sd",
@@ -2225,7 +2225,7 @@ dependencies = [
 
 [[package]]
 name = "ncro-health"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "ncro-config",
  "ncro-s3",
@@ -2235,7 +2235,7 @@ dependencies = [
 
 [[package]]
 name = "ncro-mesh"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -2251,14 +2251,14 @@ dependencies = [
 
 [[package]]
 name = "ncro-metrics"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "prometheus",
 ]
 
 [[package]]
 name = "ncro-narinfo"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -2269,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "ncro-router"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "chrono",
  "dashmap",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "ncro-s3"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",
@@ -2303,7 +2303,7 @@ dependencies = [
 
 [[package]]
 name = "ncro-server"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "axum",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2169,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "ncro"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "ncro-config"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "hex",
  "humantime-serde",
@@ -2202,7 +2202,7 @@ dependencies = [
 
 [[package]]
 name = "ncro-db"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "chrono",
  "serde",
@@ -2213,7 +2213,7 @@ dependencies = [
 
 [[package]]
 name = "ncro-discovery"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "mdns-sd",
@@ -2225,7 +2225,7 @@ dependencies = [
 
 [[package]]
 name = "ncro-health"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "ncro-config",
  "ncro-s3",
@@ -2235,7 +2235,7 @@ dependencies = [
 
 [[package]]
 name = "ncro-mesh"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -2251,14 +2251,14 @@ dependencies = [
 
 [[package]]
 name = "ncro-metrics"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "prometheus",
 ]
 
 [[package]]
 name = "ncro-narinfo"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -2269,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "ncro-router"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "chrono",
  "dashmap",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "ncro-s3"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",
@@ -2303,7 +2303,7 @@ dependencies = [
 
 [[package]]
 name = "ncro-server"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "axum",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,22 +7,23 @@ description  = "Nix Cache Route Optimizer"
 edition      = "2024"
 homepage     = "https://github.com/feel-co/ncro"
 license      = "EUPL-1.2"
+readme       = "./README.md"
 repository   = "https://github.com/feel-co/ncro"
 rust-version = "1.90.0"
-version      = "2.1.1"
+version      = "2.2.0"
 
 [workspace.dependencies]
 # Workspace components
-ncro-config    = { path = "./crates/config", version = "2.1.1" }
-ncro-db        = { path = "./crates/db", version = "2.1.1" }
-ncro-discovery = { path = "./crates/discovery", version = "2.1.1" }
-ncro-health    = { path = "./crates/health", version = "2.1.1" }
-ncro-mesh      = { path = "./crates/mesh", version = "2.1.1" }
-ncro-metrics   = { path = "./crates/metrics", version = "2.1.1" }
-ncro-narinfo   = { path = "./crates/narinfo", version = "2.1.1" }
-ncro-router    = { path = "./crates/router", version = "2.1.1" }
-ncro-s3        = { path = "./crates/s3", version = "2.1.1" }
-ncro-server    = { path = "./crates/server", version = "2.1.1" }
+ncro-config    = { path = "./crates/config", version = "2.2.0" }
+ncro-db        = { path = "./crates/db", version = "2.2.0" }
+ncro-discovery = { path = "./crates/discovery", version = "2.2.0" }
+ncro-health    = { path = "./crates/health", version = "2.2.0" }
+ncro-mesh      = { path = "./crates/mesh", version = "2.2.0" }
+ncro-metrics   = { path = "./crates/metrics", version = "2.2.0" }
+ncro-narinfo   = { path = "./crates/narinfo", version = "2.2.0" }
+ncro-router    = { path = "./crates/router", version = "2.2.0" }
+ncro-s3        = { path = "./crates/s3", version = "2.2.0" }
+ncro-server    = { path = "./crates/server", version = "2.2.0" }
 
 # Other deps
 anyhow             = "1.0.102"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,20 +9,20 @@ homepage     = "https://github.com/feel-co/ncro"
 license      = "EUPL-1.2"
 repository   = "https://github.com/feel-co/ncro"
 rust-version = "1.90.0"
-version      = "2.1.0"
+version      = "2.1.1"
 
 [workspace.dependencies]
 # Workspace components
-ncro-config    = { path = "./crates/config", version = "2.1.0" }
-ncro-db        = { path = "./crates/db", version = "2.1.0" }
-ncro-discovery = { path = "./crates/discovery", version = "2.1.0" }
-ncro-health    = { path = "./crates/health", version = "2.1.0" }
-ncro-mesh      = { path = "./crates/mesh", version = "2.1.0" }
-ncro-metrics   = { path = "./crates/metrics", version = "2.1.0" }
-ncro-narinfo   = { path = "./crates/narinfo", version = "2.1.0" }
-ncro-router    = { path = "./crates/router", version = "2.1.0" }
-ncro-s3        = { path = "./crates/s3", version = "2.1.0" }
-ncro-server    = { path = "./crates/server", version = "2.1.0" }
+ncro-config    = { path = "./crates/config", version = "2.1.1" }
+ncro-db        = { path = "./crates/db", version = "2.1.1" }
+ncro-discovery = { path = "./crates/discovery", version = "2.1.1" }
+ncro-health    = { path = "./crates/health", version = "2.1.1" }
+ncro-mesh      = { path = "./crates/mesh", version = "2.1.1" }
+ncro-metrics   = { path = "./crates/metrics", version = "2.1.1" }
+ncro-narinfo   = { path = "./crates/narinfo", version = "2.1.1" }
+ncro-router    = { path = "./crates/router", version = "2.1.1" }
+ncro-s3        = { path = "./crates/s3", version = "2.1.1" }
+ncro-server    = { path = "./crates/server", version = "2.1.1" }
 
 # Other deps
 anyhow             = "1.0.102"

--- a/README.md
+++ b/README.md
@@ -77,8 +77,10 @@ The request flow follows two distinct paths depending on the request type:
    upstream without probing others
 3. On a miss, it races HEAD requests to all configured upstreams in parallel
 4. The fastest upstream wins; the full narinfo body is fetched from that
-   upstream and returned to the client
-5. The winning route is persisted with a configurable TTL; subsequent requests
+   upstream and checked against any per-upstream filters
+5. If the upstream is rejected by filters, ncro tries the remaining candidates;
+   otherwise the narinfo is returned to the client
+6. The winning route is persisted with a configurable TTL; subsequent requests
    for the same hash use the cached route directly
 
 ### NAR Streaming
@@ -120,6 +122,9 @@ further in the [architechture document].
 - On a cache miss, ncro races all configured upstreams in parallel and returns
   the first successful response. Unhealthy upstreams (detected by consecutive
   probe failures) are excluded from the race until they recover.
+- Per-upstream filters are applied after ncro fetches the full narinfo from a
+  candidate winner. Rejected upstreams are not cached as winners and ncro keeps
+  looking for another acceptable upstream.
 
 ## Quick Start
 
@@ -219,6 +224,51 @@ gossip_interval = "30s"
 
 Environment overrides are useful for containerized or Systemd deployments where
 you want a fixed config file but still need to tweak one or two settings.
+
+### Path Filters
+
+Upstreams can have allow/deny filters. Filters are evaluated after an upstream
+wins the narinfo race, because the incoming request only contains the store hash
+(`/<hash>.narinfo`) and the full `StorePath` is only available after fetching
+the narinfo body.
+
+```toml
+[[upstreams]]
+url = "https://max.cachix.org"
+priority = 100
+
+[[upstreams.filters]]
+action  = "allow"
+field   = "name"
+pattern = "zedless*"
+
+[[upstreams.filters]]
+action  = "deny"
+field   = "name"
+pattern = "*-source"
+```
+
+Supported actions:
+
+- `allow`
+- `deny`
+
+Supported fields:
+
+- `name`: store path name after the hash, such as `zedless-0.1.0`
+- `store_path`: full `/nix/store/<hash>-<name>` path
+- `reference`: entries from the narinfo `References` field
+- `deriver`: the narinfo `Deriver` field
+
+Patterns support `*` wildcards. A deny rule always rejects a matching narinfo.
+If an upstream has at least one allow rule, at least one allow rule must match;
+otherwise the upstream is rejected. If an upstream has no allow rules, it is
+accepted unless a deny rule matches.
+
+For a project-specific cache that should only serve `zedless`, prefer a high
+`priority` plus an allow filter. The high priority keeps it behind general
+caches for routing, while the filter prevents unrelated paths from being
+accepted if the cache happens to respond first.
 
 ### S3 Upstreams
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -13,6 +13,14 @@ url        = "https://cache.nixos.org"
 priority = 20
 url      = "https://nix-community.cachix.org"
 
+# Optional per-upstream filters. Deny rules always reject matching paths. If an
+# upstream has any allow rules, at least one allow rule must match.
+#
+# [[upstreams.filters]]
+# action  = "allow"      # allow | deny
+# field   = "name"       # name | store_path | reference | deriver
+# pattern = "zedless*"   # supports '*' wildcards
+
 [cache]
 db_path       = "/var/lib/ncro/routes.db"
 latency_alpha = 0.3

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -138,6 +138,20 @@ mod tests {
   }
 
   #[test]
+  fn parses_upstream_filters() -> Result<(), ConfigError> {
+    let cfg: Config = toml::from_str(
+      "[[upstreams]]\nurl = \"https://cache.example\"\n\n\
+       [[upstreams.filters]]\naction = \"allow\"\nfield = \"name\"\npattern = \"zedless*\"\n\n\
+       [[upstreams.filters]]\naction = \"deny\"\nfield = \"store_path\"\npattern = \"*-source\"\n",
+    )?;
+    cfg.validate()?;
+    assert_eq!(cfg.upstreams[0].filters.len(), 2);
+    assert_eq!(cfg.upstreams[0].filters[0].action, FilterAction::Allow);
+    assert_eq!(cfg.upstreams[0].filters[0].field, FilterField::Name);
+    Ok(())
+  }
+
+  #[test]
   fn s3_url_custom_endpoint_http() -> Result<(), ConfigError> {
     assert_eq!(
       parse_s3_url(
@@ -277,6 +291,32 @@ impl<'de> Deserialize<'de> for HumanDuration {
   }
 }
 
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum FilterAction {
+  #[default]
+  Allow,
+  Deny,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FilterField {
+  #[default]
+  Name,
+  StorePath,
+  Reference,
+  Deriver,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct FilterRule {
+  pub action:  FilterAction,
+  pub field:   FilterField,
+  pub pattern: String,
+}
+
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
 pub struct UpstreamConfig {
@@ -285,6 +325,7 @@ pub struct UpstreamConfig {
   pub public_key: String,
   pub username:   String,
   pub password:   Option<String>,
+  pub filters:    Vec<FilterRule>,
   #[serde(skip)]
   pub s3:         Option<S3Config>,
 }
@@ -532,6 +573,13 @@ impl Config {
         return Err(ConfigError::Validation(format!(
           "upstream[{i}]: public_key must be in 'name:base64(key)' Nix format"
         )));
+      }
+      for (j, filter) in upstream.filters.iter().enumerate() {
+        if filter.pattern.is_empty() {
+          return Err(ConfigError::Validation(format!(
+            "upstream[{i}].filters[{j}]: pattern is empty"
+          )));
+        }
       }
     }
     if self.server.cache_priority < 1 {

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -288,6 +288,16 @@ impl Router {
     store_hash: &str,
   ) -> Result<Option<ResolveResult>, RouterError> {
     if let Some(cached) = self.inner.lru.get(store_hash).await {
+      if !self
+        .cached_route_allows_filters(
+          &cached.url,
+          cached.narinfo_bytes.as_deref(),
+        )
+        .await
+      {
+        self.inner.lru.invalidate(store_hash).await;
+        return Ok(None);
+      }
       ncro_metrics::get().narinfo_cache_hits.inc();
       return Ok(Some((*cached).clone()));
     }
@@ -299,6 +309,15 @@ impl Router {
     }
     let health = self.inner.prober.get_health(&entry.upstream_url).await;
     if health.as_ref().is_some_and(|h| h.status == Status::Down) {
+      return Ok(None);
+    }
+    if !self
+      .cached_route_allows_filters(
+        &entry.upstream_url,
+        entry.narinfo_bytes.as_deref(),
+      )
+      .await
+    {
       return Ok(None);
     }
     ncro_metrics::get().narinfo_cache_hits.inc();
@@ -338,7 +357,7 @@ impl Router {
       filtered
     };
 
-    // Group candidates by priority. Lower number meanshigher priority, tried
+    // Group candidates by priority. Lower number means higher priority, tried
     // first. Upstreams whose health entry is missing get i32::MAX so that they
     // fall into the lowest-priority group rather than being silently dropped.
     let mut groups: BTreeMap<i32, Vec<String>> = BTreeMap::new();
@@ -363,18 +382,33 @@ impl Router {
         match group_result {
           Ok(winner) => {
             let winner_url = winner.url.clone();
-            match self.commit_winner(winner, store_hash).await? {
-              CommitOutcome::Accepted(result) => {
+            match self.commit_winner(winner, store_hash).await {
+              Ok(CommitOutcome::Accepted(result)) => {
                 ncro_metrics::get()
                   .narinfo_upstream_attempts_per_resolve
                   .with_label_values(&["success"])
                   .observe(f64::from(attempts_total));
                 return Ok(result);
               },
-              CommitOutcome::Rejected => {
+              Ok(CommitOutcome::Rejected) => {
                 any_not_found = true;
                 group_candidates.retain(|url| url != &winner_url);
               },
+              Err(err) if commit_error_is_retryable(&err) => {
+                if commit_error_is_network_like(&err) {
+                  self.mark_cooldown(&winner_url);
+                } else {
+                  any_not_found = true;
+                }
+                tracing::warn!(
+                  upstream = &winner_url,
+                  store = store_hash,
+                  error = %err,
+                  "narinfo winner could not be committed; trying next candidate"
+                );
+                group_candidates.retain(|url| url != &winner_url);
+              },
+              Err(err) => return Err(err),
             }
           },
           Err(RaceGroupError::NotFound) => {
@@ -669,6 +703,29 @@ impl Router {
     !has_allow || allow_matched
   }
 
+  async fn cached_route_allows_filters(
+    &self,
+    upstream: &str,
+    narinfo_bytes: Option<&[u8]>,
+  ) -> bool {
+    if !self
+      .inner
+      .upstream_filters
+      .read()
+      .await
+      .contains_key(upstream)
+    {
+      return true;
+    }
+    let Some(bytes) = narinfo_bytes else {
+      return false;
+    };
+    let Ok(narinfo) = NarInfo::parse(bytes) else {
+      return false;
+    };
+    self.upstream_allows_narinfo(upstream, &narinfo).await
+  }
+
   async fn fetch_narinfo(
     &self,
     upstream: &str,
@@ -729,6 +786,17 @@ fn filter_rule_matches(rule: &FilterRule, narinfo: &NarInfo) -> bool {
   }
 }
 
+const fn commit_error_is_retryable(err: &RouterError) -> bool {
+  matches!(
+    err,
+    RouterError::NotFound | RouterError::FetchNarinfo(_) | RouterError::S3(_)
+  )
+}
+
+const fn commit_error_is_network_like(err: &RouterError) -> bool {
+  matches!(err, RouterError::FetchNarinfo(_) | RouterError::S3(_))
+}
+
 fn store_path_name(store_path: &str) -> &str {
   let Some(base) = store_path.rsplit('/').next() else {
     return store_path;
@@ -771,9 +839,14 @@ mod tests {
   #![expect(clippy::unwrap_used, reason = "Fine in tests")]
   use std::{sync::Arc, time::Duration};
 
+  use ncro_config::UpstreamConfig;
   use ncro_db::Db;
   use ncro_health::Prober;
-  use tokio::sync::Mutex;
+  use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+    sync::Mutex,
+  };
 
   use super::{
     FilterAction,
@@ -789,8 +862,16 @@ mod tests {
   };
 
   async fn make_router(cooldown: Duration) -> Router {
+    make_router_with_upstreams(cooldown, &[]).await
+  }
+
+  async fn make_router_with_upstreams(
+    cooldown: Duration,
+    upstreams: &[UpstreamConfig],
+  ) -> Router {
     let db = Db::open(":memory:", 100).await.unwrap();
     let prober = Prober::new(0.3).unwrap();
+    prober.init_upstreams(upstreams).await;
     Router::new(
       db,
       prober,
@@ -805,6 +886,76 @@ mod tests {
       },
     )
     .unwrap()
+  }
+
+  async fn spawn_narinfo_server(get_status: u16, store_name: &str) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let store_name = store_name.to_string();
+    tokio::spawn(async move {
+      loop {
+        let Ok((mut stream, _)) = listener.accept().await else {
+          return;
+        };
+        let store_name = store_name.clone();
+        tokio::spawn(async move {
+          let mut buf = [0_u8; 1024];
+          let Ok(n) = stream.read(&mut buf).await else {
+            return;
+          };
+          let request = String::from_utf8_lossy(&buf[..n]);
+          if request.starts_with("HEAD ") {
+            let _ = stream
+              .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+              .await;
+            return;
+          }
+          if request.starts_with("GET ") && get_status == 200 {
+            let body = format!(
+              "StorePath: /nix/store/abc123-{store_name}\nURL: \
+               nar/test.nar.xz\nCompression: xz\nNarHash: \
+               sha256:abc\nNarSize: 1\nReferences: \n"
+            );
+            let response = format!(
+              "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+              body.len(),
+              body
+            );
+            let _ = stream.write_all(response.as_bytes()).await;
+            return;
+          }
+          let _ = stream
+            .write_all(b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n")
+            .await;
+        });
+      }
+    });
+    format!("http://{addr}")
+  }
+
+  async fn spawn_head_ok_get_drop_server() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+      loop {
+        let Ok((mut stream, _)) = listener.accept().await else {
+          return;
+        };
+        tokio::spawn(async move {
+          let mut buf = [0_u8; 1024];
+          let Ok(n) = stream.read(&mut buf).await else {
+            return;
+          };
+          let request = String::from_utf8_lossy(&buf[..n]);
+          if request.starts_with("HEAD ") {
+            let _ = stream
+              .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+              .await;
+          }
+        });
+      }
+    });
+    format!("http://{addr}")
   }
 
   #[test]
@@ -848,6 +999,134 @@ mod tests {
       },
       &narinfo,
     ));
+  }
+
+  #[tokio::test]
+  async fn resolve_retries_after_winner_get_returns_not_found() {
+    let failing = spawn_narinfo_server(500, "wrong").await;
+    let working = spawn_narinfo_server(200, "zedless-0.1.0").await;
+    let router = make_router_with_upstreams(Duration::from_mins(1), &[
+      UpstreamConfig {
+        url: failing.clone(),
+        priority: 1,
+        ..Default::default()
+      },
+      UpstreamConfig {
+        url: working.clone(),
+        priority: 2,
+        ..Default::default()
+      },
+    ])
+    .await;
+
+    let result = router
+      .resolve("abc123", &[failing.clone(), working.clone()])
+      .await
+      .unwrap();
+
+    assert_eq!(result.url, working);
+    assert!(!router.in_cooldown(&failing));
+  }
+
+  #[tokio::test]
+  async fn resolve_retries_after_winner_get_network_error() {
+    let failing = spawn_head_ok_get_drop_server().await;
+    let working = spawn_narinfo_server(200, "zedless-0.1.0").await;
+    let router = make_router_with_upstreams(Duration::from_mins(1), &[
+      UpstreamConfig {
+        url: failing.clone(),
+        priority: 1,
+        ..Default::default()
+      },
+      UpstreamConfig {
+        url: working.clone(),
+        priority: 2,
+        ..Default::default()
+      },
+    ])
+    .await;
+
+    let result = router
+      .resolve("abc123", &[failing.clone(), working.clone()])
+      .await
+      .unwrap();
+
+    assert_eq!(result.url, working);
+    assert!(router.in_cooldown(&failing));
+  }
+
+  #[tokio::test]
+  async fn resolve_retries_after_filter_rejects_winner() {
+    let rejected = spawn_narinfo_server(200, "unrelated-1.0").await;
+    let accepted = spawn_narinfo_server(200, "zedless-0.1.0").await;
+    let router = make_router_with_upstreams(Duration::from_mins(1), &[
+      UpstreamConfig {
+        url: rejected.clone(),
+        priority: 1,
+        ..Default::default()
+      },
+      UpstreamConfig {
+        url: accepted.clone(),
+        priority: 2,
+        ..Default::default()
+      },
+    ])
+    .await;
+    router
+      .set_upstream_filters(rejected.clone(), vec![FilterRule {
+        action:  FilterAction::Allow,
+        field:   FilterField::Name,
+        pattern: "zedless*".to_string(),
+      }])
+      .await;
+
+    let result = router
+      .resolve("abc123", &[rejected, accepted.clone()])
+      .await
+      .unwrap();
+
+    assert_eq!(result.url, accepted);
+  }
+
+  #[tokio::test]
+  async fn cached_route_is_revalidated_against_new_filters() {
+    let previously_accepted = spawn_narinfo_server(200, "unrelated-1.0").await;
+    let accepted = spawn_narinfo_server(200, "zedless-0.1.0").await;
+    let router = make_router_with_upstreams(Duration::from_mins(1), &[
+      UpstreamConfig {
+        url: previously_accepted.clone(),
+        priority: 1,
+        ..Default::default()
+      },
+      UpstreamConfig {
+        url: accepted.clone(),
+        priority: 2,
+        ..Default::default()
+      },
+    ])
+    .await;
+
+    let cached = router
+      .resolve("abc123", std::slice::from_ref(&previously_accepted))
+      .await
+      .unwrap();
+    assert_eq!(cached.url, previously_accepted);
+
+    router
+      .set_upstream_filters(previously_accepted.clone(), vec![FilterRule {
+        action:  FilterAction::Allow,
+        field:   FilterField::Name,
+        pattern: "zedless*".to_string(),
+      }])
+      .await;
+
+    let result = router
+      .resolve("abc123", &[previously_accepted, accepted.clone()])
+      .await
+      .unwrap();
+
+    assert_eq!(result.url, accepted);
+    assert!(!result.cache_hit);
   }
 
   #[test]

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -8,6 +8,7 @@ use chrono::Utc;
 use dashmap::{DashMap, mapref::entry::Entry};
 use futures_util::{StreamExt, stream::FuturesUnordered};
 use moka::future::Cache as MokaCache;
+use ncro_config::{FilterAction, FilterField, FilterRule};
 use ncro_db::{Db, DbError, RouteEntry};
 use ncro_health::{Prober, Status};
 use ncro_narinfo::{NarInfo, NarInfoError, parse_public_key};
@@ -66,6 +67,7 @@ struct RouterInner {
   s3:                       S3ClientPool,
   upstream_keys:            RwLock<HashMap<String, String>>,
   upstream_auth:            RwLock<HashMap<String, (String, Option<String>)>>,
+  upstream_filters:         RwLock<HashMap<String, Vec<FilterRule>>>,
   inflight:                 DashMap<String, Arc<Mutex<()>>>,
   lru:                      MokaCache<String, Arc<ResolveResult>>,
   miss_lru:                 MokaCache<String, ()>,
@@ -80,6 +82,11 @@ struct RouterInner {
 struct RaceResult {
   url:        String,
   latency_ms: f64,
+}
+
+enum CommitOutcome {
+  Accepted(ResolveResult),
+  Rejected,
 }
 
 /// Outcome of racing a single priority group.
@@ -140,6 +147,7 @@ impl Router {
         s3: S3ClientPool::default(),
         upstream_keys: RwLock::new(HashMap::new()),
         upstream_auth: RwLock::new(HashMap::new()),
+        upstream_filters: RwLock::new(HashMap::new()),
         inflight: DashMap::new(),
         lru: MokaCache::builder()
           .max_capacity(1024)
@@ -192,6 +200,22 @@ impl Router {
       .write()
       .await
       .insert(url, (username, password));
+  }
+
+  pub async fn set_upstream_filters(
+    &self,
+    url: String,
+    filters: Vec<FilterRule>,
+  ) {
+    if filters.is_empty() {
+      return;
+    }
+    self
+      .inner
+      .upstream_filters
+      .write()
+      .await
+      .insert(url, filters);
   }
 
   pub fn register_s3_upstream(
@@ -331,20 +355,36 @@ impl Router {
     let mut any_not_found = false;
     let mut attempts_total = 0_u32;
     for (_priority, group) in groups {
-      let (group_result, attempts) = self.race_group(store_hash, &group).await;
-      attempts_total += attempts;
-      match group_result {
-        Ok(winner) => {
-          ncro_metrics::get()
-            .narinfo_upstream_attempts_per_resolve
-            .with_label_values(&["success"])
-            .observe(f64::from(attempts_total));
-          return self.commit_winner(winner, store_hash).await;
-        },
-        Err(RaceGroupError::NotFound) => any_not_found = true,
-        // Try the next priority group on network error; those upstreams were
-        // unreachable so we cannot conclude the path is absent.
-        Err(RaceGroupError::NetworkError | RaceGroupError::Timeout) => {},
+      let mut group_candidates = group;
+      while !group_candidates.is_empty() {
+        let (group_result, attempts) =
+          self.race_group(store_hash, &group_candidates).await;
+        attempts_total += attempts;
+        match group_result {
+          Ok(winner) => {
+            let winner_url = winner.url.clone();
+            match self.commit_winner(winner, store_hash).await? {
+              CommitOutcome::Accepted(result) => {
+                ncro_metrics::get()
+                  .narinfo_upstream_attempts_per_resolve
+                  .with_label_values(&["success"])
+                  .observe(f64::from(attempts_total));
+                return Ok(result);
+              },
+              CommitOutcome::Rejected => {
+                any_not_found = true;
+                group_candidates.retain(|url| url != &winner_url);
+              },
+            }
+          },
+          Err(RaceGroupError::NotFound) => {
+            any_not_found = true;
+            break;
+          },
+          // Try the next priority group on network error; those upstreams were
+          // unreachable so we cannot conclude the path is absent.
+          Err(RaceGroupError::NetworkError | RaceGroupError::Timeout) => break,
+        }
       }
     }
     ncro_metrics::get()
@@ -519,15 +559,23 @@ impl Router {
     &self,
     winner: RaceResult,
     store_hash: &str,
-  ) -> Result<ResolveResult, RouterError> {
-    let (body, raw_nar_url, nar_hash, nar_size) =
-      self.fetch_narinfo(&winner.url, store_hash).await?;
+  ) -> Result<CommitOutcome, RouterError> {
+    let (body, parsed) = self.fetch_narinfo(&winner.url, store_hash).await?;
+    if !self.upstream_allows_narinfo(&winner.url, &parsed).await {
+      tracing::debug!(
+        upstream = &winner.url,
+        store_path = &parsed.store_path,
+        "narinfo rejected by upstream filter"
+      );
+      return Ok(CommitOutcome::Rejected);
+    }
     // Strip leading slash and query string (harmonia appends ?hash=STORE_HASH)
     // so the DB key is just the path component for consistent lookups.
-    let nar_url = raw_nar_url
+    let nar_url = parsed
+      .url
       .trim_start_matches('/')
       .split_once('?')
-      .map_or_else(|| raw_nar_url.trim_start_matches('/'), |(path, _)| path)
+      .map_or_else(|| parsed.url.trim_start_matches('/'), |(path, _)| path)
       .to_string();
 
     ncro_metrics::get()
@@ -568,8 +616,8 @@ impl Router {
         ttl: now
           + chrono::Duration::from_std(self.inner.route_ttl)
             .unwrap_or_default(),
-        nar_hash,
-        nar_size,
+        nar_hash: parsed.nar_hash,
+        nar_size: parsed.nar_size,
         nar_url,
         narinfo_bytes: body.clone(),
       })
@@ -585,14 +633,47 @@ impl Router {
       .lru
       .insert(store_hash.to_string(), Arc::new(result.clone()))
       .await;
-    Ok(result)
+    Ok(CommitOutcome::Accepted(result))
+  }
+
+  async fn upstream_allows_narinfo(
+    &self,
+    upstream: &str,
+    narinfo: &NarInfo,
+  ) -> bool {
+    let rules = {
+      let filters = self.inner.upstream_filters.read().await;
+      filters.get(upstream).cloned()
+    };
+    let Some(rules) = rules else {
+      return true;
+    };
+    if rules.is_empty() {
+      return true;
+    }
+
+    let has_allow = rules
+      .iter()
+      .any(|rule| matches!(rule.action, FilterAction::Allow));
+    let mut allow_matched = false;
+    for rule in &rules {
+      if !filter_rule_matches(rule, narinfo) {
+        continue;
+      }
+      match rule.action {
+        FilterAction::Deny => return false,
+        FilterAction::Allow => allow_matched = true,
+      }
+    }
+
+    !has_allow || allow_matched
   }
 
   async fn fetch_narinfo(
     &self,
     upstream: &str,
     store_hash: &str,
-  ) -> Result<(Option<Vec<u8>>, String, String, u64), RouterError> {
+  ) -> Result<(Option<Vec<u8>>, NarInfo), RouterError> {
     let body = if self.inner.s3.contains(upstream) {
       self
         .inner
@@ -626,8 +707,63 @@ impl Router {
       );
       return Err(RouterError::SignatureVerificationFailed);
     }
-    Ok((Some(body), parsed.url, parsed.nar_hash, parsed.nar_size))
+    Ok((Some(body), parsed))
   }
+}
+
+fn filter_rule_matches(rule: &FilterRule, narinfo: &NarInfo) -> bool {
+  match rule.field {
+    FilterField::StorePath => {
+      wildcard_match(&rule.pattern, &narinfo.store_path)
+    },
+    FilterField::Name => {
+      wildcard_match(&rule.pattern, store_path_name(&narinfo.store_path))
+    },
+    FilterField::Reference => {
+      narinfo
+        .references
+        .iter()
+        .any(|reference| wildcard_match(&rule.pattern, reference))
+    },
+    FilterField::Deriver => wildcard_match(&rule.pattern, &narinfo.deriver),
+  }
+}
+
+fn store_path_name(store_path: &str) -> &str {
+  let Some(base) = store_path.rsplit('/').next() else {
+    return store_path;
+  };
+  base.split_once('-').map_or(base, |(_, name)| name)
+}
+
+fn wildcard_match(pattern: &str, value: &str) -> bool {
+  if pattern == "*" {
+    return true;
+  }
+  let mut remainder = value;
+  let parts = pattern.split('*');
+  let anchored_start = !pattern.starts_with('*');
+  let anchored_end = !pattern.ends_with('*');
+  let mut first = true;
+
+  for part in parts {
+    if part.is_empty() {
+      continue;
+    }
+    if first && anchored_start {
+      let Some(next) = remainder.strip_prefix(part) else {
+        return false;
+      };
+      remainder = next;
+    } else if let Some(index) = remainder.find(part) {
+      remainder = &remainder[index + part.len()..];
+    } else {
+      return false;
+    }
+    first = false;
+  }
+
+  !anchored_end || remainder.is_empty()
 }
 
 #[cfg(test)]
@@ -639,7 +775,18 @@ mod tests {
   use ncro_health::Prober;
   use tokio::sync::Mutex;
 
-  use super::{InflightGuard, Router, RouterTuning};
+  use super::{
+    FilterAction,
+    FilterField,
+    FilterRule,
+    InflightGuard,
+    NarInfo,
+    Router,
+    RouterTuning,
+    filter_rule_matches,
+    store_path_name,
+    wildcard_match,
+  };
 
   async fn make_router(cooldown: Duration) -> Router {
     let db = Db::open(":memory:", 100).await.unwrap();
@@ -658,6 +805,49 @@ mod tests {
       },
     )
     .unwrap()
+  }
+
+  #[test]
+  fn extracts_store_path_name() {
+    assert_eq!(
+      store_path_name("/nix/store/abc123-zedless-0.1.0"),
+      "zedless-0.1.0"
+    );
+  }
+
+  #[test]
+  fn wildcard_patterns_match_expected_values() {
+    assert!(wildcard_match("zedless*", "zedless-0.1.0"));
+    assert!(wildcard_match("*-source", "foo-source"));
+    assert!(wildcard_match("*zed*", "my-zedless-package"));
+    assert!(!wildcard_match("zedless", "zedless-0.1.0"));
+  }
+
+  #[test]
+  fn filter_rules_match_selected_fields() {
+    let narinfo = NarInfo {
+      store_path: "/nix/store/abc123-zedless-0.1.0".to_string(),
+      references: vec!["dep-one".to_string()],
+      deriver: "abc123-zedless.drv".to_string(),
+      ..Default::default()
+    };
+
+    assert!(filter_rule_matches(
+      &FilterRule {
+        action:  FilterAction::Allow,
+        field:   FilterField::Name,
+        pattern: "zedless*".to_string(),
+      },
+      &narinfo,
+    ));
+    assert!(filter_rule_matches(
+      &FilterRule {
+        action:  FilterAction::Deny,
+        field:   FilterField::Reference,
+        pattern: "dep-*".to_string(),
+      },
+      &narinfo,
+    ));
   }
 
   #[test]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,10 +35,22 @@ sequenceDiagram
   else cache miss
     N->>U: race requests in parallel
     U-->>N: first success wins
-    N->>S: store route
+    N->>N: parse narinfo and apply upstream filters
+    alt accepted
+      N->>S: store route
+    else rejected
+      N->>U: continue with remaining candidates
+    end
   end
   N-->>C: response
 ```
+
+Path filters sit after the narinfo fetch, not before the upstream race. A Nix
+client requests `/<hash>.narinfo`, so ncro only knows the store hash at the start
+of routing. The full `StorePath`, references, and deriver are inside the narinfo
+body. This means filtering is a validation step for candidate winners: if a
+winning upstream's narinfo is rejected, the route is not cached and ncro retries
+the remaining candidates.
 
 NAR streaming, on another hand, follows a different path. There is actually no
 race and when a client requests `/nar/<hash>.nar`, ncro looks up the route for
@@ -88,6 +100,8 @@ flowchart TD
 Selection is driven by latency first. When two upstreams are effectively tied,
 `priority` breaks the tie. The router also tracks failures and probe volume so
 it can distinguish a briefly slow cache from one that is trending unhealthy.
+Per-upstream filters can reject a candidate winner after its narinfo is fetched;
+this prevents project-specific caches from becoming winners for unrelated paths.
 
 > [!TIP]
 > Persistence is intentionally narrow. SQLite stores two kinds of data so a
@@ -126,7 +140,13 @@ The most important settings are `upstreams`, `server.listen`, `cache.db_path`,
 `server.cache_priority`, `discovery.enabled`, `discovery.address_family`, and `mesh.enabled`.
 
 `upstreams` defines the cache backends ncro can use. Each upstream can carry a
-`priority` value and an optional `public_key` for mesh verification.
+`priority` value, optional Basic Auth credentials, an optional `public_key` for
+narinfo signature verification, and optional `filters`.
+
+Upstream filters support `allow` and `deny` rules over narinfo fields. The
+available fields are `name`, `store_path`, `reference`, and `deriver`; patterns
+use `*` wildcards. Deny rules always win. If any allow rules are configured for
+an upstream, at least one must match for that upstream to be accepted.
 
 `cache.ttl` is how long a successful routing decision remains trusted. The
 negative TTL applies to failed lookups so ncro does not immediately retry the

--- a/ncro/Cargo.toml
+++ b/ncro/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace     = true
 description.workspace = true
 homepage.workspace    = true
 repository.workspace  = true
+readme.workspace      = true
 
 [dependencies]
 anyhow.workspace   = true

--- a/ncro/src/cli.rs
+++ b/ncro/src/cli.rs
@@ -154,6 +154,9 @@ pub async fn run() -> anyhow::Result<()> {
         )
         .await;
     }
+    router
+      .set_upstream_filters(upstream.url.clone(), upstream.filters.clone())
+      .await;
   }
 
   let (stop_tx, stop_rx) = tokio::sync::watch::channel(false);

--- a/nix/tests/e2e.nix
+++ b/nix/tests/e2e.nix
@@ -15,6 +15,13 @@
     echo "e2e payload 2: harmonia backend" > "$out/data"
   '';
 
+  # Present in both backends. The filtered ncro node rejects this path on the
+  # priority-1 backend, so a successful response must come from backend 2.
+  filterPayload = pkgs.runCommandLocal "ncro-e2e-filter-payload" {} ''
+    mkdir -p "$out"
+    echo "e2e filter payload: available on both backends" > "$out/data"
+  '';
+
   cacheKey1Name = "ncro-e2e-cache1";
   cacheKey2Name = "ncro-e2e-cache2";
 
@@ -39,7 +46,7 @@ in
       }: {
         imports = [commonBase];
 
-        system.extraDependencies = [payload1];
+        system.extraDependencies = [payload1 filterPayload];
 
         systemd.services.setup-cache = {
           description = "Generate signing key and sign e2e payload 1";
@@ -64,6 +71,9 @@ in
               ${config.nix.package}/bin/nix store sign \
                 --key-file /etc/nix/cache-key.sec \
                 "${payload1}"
+              ${config.nix.package}/bin/nix store sign \
+                --key-file /etc/nix/cache-key.sec \
+                "${filterPayload}"
             '';
           };
         };
@@ -96,7 +106,7 @@ in
       }: {
         imports = [commonBase];
 
-        system.extraDependencies = [payload2];
+        system.extraDependencies = [payload2 filterPayload];
 
         systemd.services.setup-cache = {
           description = "Generate signing key and sign e2e payload 2";
@@ -109,6 +119,7 @@ in
             RemainAfterExit = true;
             ExecStart = pkgs.writeShellScript "setup-cache2" ''
               set -euo pipefail
+
               mkdir -p /etc/nix
               if [ ! -f /etc/nix/cache-key.sec ]; then
                 ${config.nix.package}/bin/nix-store \
@@ -116,10 +127,12 @@ in
                   /etc/nix/cache-key.sec \
                   /etc/nix/cache-key.pub
               fi
+
               chmod 644 /etc/nix/cache-key.pub /etc/nix/cache-key.sec
-              ${config.nix.package}/bin/nix store sign \
-                --key-file /etc/nix/cache-key.sec \
-                "${payload2}"
+              for path in "${payload2}" "${filterPayload}"; do
+                ${config.nix.package}/bin/nix store sign "$path" \
+                  --key-file /etc/nix/cache-key.sec
+              done
             '';
           };
         };
@@ -139,7 +152,7 @@ in
       };
 
       # First ncro instance. Proxies to both binary caches.
-      host = {...}: {
+      host = {
         imports = [
           self.nixosModules.ncro
           commonBase
@@ -173,7 +186,7 @@ in
       # Second ncro instance. Proxies exclusively through host's ncro,
       # exercising the two-hop path:
       # secondary --> host --> bincache.
-      secondary = {...}: {
+      secondary = {
         imports = [
           self.nixosModules.ncro
           commonBase
@@ -191,6 +204,45 @@ in
                 priority = 1;
               }
             ];
+            cache = {
+              ttl = "5m";
+              negative_ttl = "30s";
+            };
+          };
+        };
+      };
+
+      # Third ncro instance. Both upstreams can serve filterPayload, but the
+      # priority-1 upstream is configured to allow only payload1 by name. This
+      # exercises post-narinfo filter rejection and fallback to the next backend.
+      filtered = {
+        imports = [
+          self.nixosModules.ncro
+          commonBase
+        ];
+
+        services.ncro = {
+          enable = true;
+          settings = {
+            server.listen = ":8080";
+            upstreams = [
+              {
+                url = "http://bincache1:5000";
+                priority = 1;
+                filters = [
+                  {
+                    action = "allow";
+                    field = "name";
+                    pattern = "ncro-e2e-payload1*";
+                  }
+                ];
+              }
+              {
+                url = "http://bincache2:5000";
+                priority = 2;
+              }
+            ];
+
             cache = {
               ttl = "5m";
               negative_ttl = "30s";
@@ -223,25 +275,29 @@ in
 
       payload1_path = "${payload1}"
       payload2_path = "${payload2}"
+      filter_payload_path = "${filterPayload}"
       hash1 = store_hash(payload1_path)
       hash2 = store_hash(payload2_path)
+      filter_hash = store_hash(filter_payload_path)
 
-      with subtest("boot all nodes"):
-          start_all()
+      start_all()
 
-          bincache1.wait_for_unit("setup-cache.service")
-          bincache1.wait_for_unit("nix-serve-ng.service")
-          bincache1.wait_for_open_port(5000)
+      bincache1.wait_for_unit("setup-cache.service")
+      bincache1.wait_for_unit("nix-serve-ng.service")
+      bincache1.wait_for_open_port(5000)
 
-          bincache2.wait_for_unit("setup-cache.service")
-          bincache2.wait_for_unit("harmonia.service")
-          bincache2.wait_for_open_port(5000)
+      bincache2.wait_for_unit("setup-cache.service")
+      bincache2.wait_for_unit("harmonia.service")
+      bincache2.wait_for_open_port(5000)
 
-          host.wait_for_unit("ncro.service")
-          host.wait_for_open_port(8080)
+      host.wait_for_unit("ncro.service")
+      host.wait_for_open_port(8080)
 
-          secondary.wait_for_unit("ncro.service")
-          secondary.wait_for_open_port(8080)
+      secondary.wait_for_unit("ncro.service")
+      secondary.wait_for_open_port(8080)
+
+      filtered.wait_for_unit("ncro.service")
+      filtered.wait_for_open_port(8080)
 
       with subtest("binary caches serve nix-cache-info"):
           for node, port in ((bincache1, 5000), (bincache2, 5000)):
@@ -266,7 +322,7 @@ in
           assert "Sig: ${cacheKey2Name}:" in out2, \
               f"bincache2 narinfo missing signature: {out2!r}"
 
-      with subtest("cross-backend: each cache returns 404 for the other's payload"):
+      with subtest("each cache returns 404 for the other's payload"):
           bincache1.fail(f"curl -sf http://localhost:5000/{hash2}.narinfo")
           bincache2.fail(f"curl -sf http://localhost:5000/{hash1}.narinfo")
 
@@ -279,6 +335,17 @@ in
           out = host.succeed(f"curl -sf http://localhost:8080/{hash2}.narinfo")
           assert "StorePath" in out, \
               f"host ncro did not proxy hash2 narinfo: {out!r}"
+
+      with subtest("path filters reject disallowed priority-1 narinfo"):
+          out = filtered.succeed(f"curl -sf http://localhost:8080/{filter_hash}.narinfo")
+          assert "StorePath" in out, \
+              f"filtered ncro did not serve shared payload narinfo: {out!r}"
+          assert "${filterPayload}" in out, \
+              f"filtered ncro returned wrong store path: {out!r}"
+          assert "Sig: ${cacheKey2Name}:" in out, \
+              f"filtered ncro did not fall back to backend 2 after filter rejection: {out!r}"
+          assert "Sig: ${cacheKey1Name}:" not in out, \
+              f"filtered ncro accepted backend 1 despite path filter: {out!r}"
 
       with subtest("secondary ncro proxies both narinfos through host (two-hop)"):
           out1 = secondary.succeed(f"curl -sf http://localhost:8080/{hash1}.narinfo")


### PR DESCRIPTION
Adds per-upstream filtering of NAR info in the router, allowing users to configure allow/deny rules based on attributes like name, store path, references, or deriver. Now there is a a flexible and configurable way to control which NAR infos are accepted from each upstream, mainly for security and reliability.