### PR TITLE
Add per-upstream timeout overrides for narinfo and NAR streaming

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -13,6 +13,12 @@ url        = "https://cache.nixos.org"
 priority = 20
 url      = "https://nix-community.cachix.org"
 
+# Optional per-upstream timeout overrides. When set, these override the global
+# timeouts for this upstream only.
+#
+# narinfo_timeout = "10s"  # overrides the router's race timeout for narinfo
+# nar_timeout     = "60s"  # overrides the server's read_timeout for NAR streams
+
 # Optional per-upstream filters. Deny rules always reject matching paths. If an
 # upstream has any allow rules, at least one allow rule must match.
 #

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -343,14 +343,34 @@ pub struct FilterRule {
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
 pub struct UpstreamConfig {
-  pub url:        String,
-  pub priority:   i32,
-  pub public_key: String,
-  pub username:   String,
-  pub password:   Option<String>,
-  pub filters:    Vec<FilterRule>,
+  /// Base URL of the substituter (http, https, or `s3://`).
+  pub url:             String,
+  /// Priority for latency tiebreaking and race ordering. Lower values are
+  /// preferred. Two upstreams within 10 % EMA latency are resolved by
+  /// this priority.
+  pub priority:        i32,
+  /// Nix-style `name:base64(key)` public key for narinfo signature
+  /// verification. Leave empty to skip verification.
+  pub public_key:      String,
+  /// HTTP Basic Auth username. Requests are made without authentication
+  /// when empty.
+  pub username:        String,
+  /// HTTP Basic Auth password.
+  pub password:        Option<String>,
+  /// Per-upstream allow/deny path filters evaluated after the narinfo is
+  /// fetched. Deny rules reject immediately; if any allow rules exist,
+  /// at least one must match.
+  pub filters:         Vec<FilterRule>,
+  /// Optional per-upstream timeout for narinfo HEAD races and GET fetches.
+  /// When unset, the router's global race timeout is used.
+  pub narinfo_timeout: Option<HumanDuration>,
+  /// Optional per-upstream timeout for NAR file streaming requests.
+  /// When unset, the server's global `read_timeout` is used.
+  pub nar_timeout:     Option<HumanDuration>,
+  /// Parsed S3 configuration derived from `url` when the scheme is `s3://`.
+  /// Not set directly in config, but populated automatically at load time.
   #[serde(skip)]
-  pub s3:         Option<S3Config>,
+  pub s3:              Option<S3Config>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -64,6 +64,7 @@ struct RouterInner {
   race_timeout:             Duration,
   negative_ttl:             Duration,
   client:                   reqwest::Client,
+  upstream_clients:         RwLock<HashMap<String, reqwest::Client>>,
   s3:                       S3ClientPool,
   upstream_keys:            RwLock<HashMap<String, String>>,
   upstream_auth:            RwLock<HashMap<String, (String, Option<String>)>>,
@@ -149,6 +150,7 @@ impl Router {
         race_timeout,
         negative_ttl,
         client: reqwest::Client::builder().timeout(race_timeout).build()?,
+        upstream_clients: RwLock::new(HashMap::new()),
         s3: S3ClientPool::default(),
         upstream_keys: RwLock::new(HashMap::new()),
         upstream_auth: RwLock::new(HashMap::new()),
@@ -229,6 +231,28 @@ impl Router {
     config: ncro_config::S3Config,
   ) {
     self.inner.s3.register(upstream, config);
+  }
+
+  /// Build and register a per-upstream HTTP client with a custom narinfo
+  /// timeout. When set, this client is used in place of the default
+  /// race-timeout client for HEAD races and GET fetches against `url`.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if the per-upstream client cannot be built.
+  pub async fn set_upstream_narinfo_timeout(
+    &self,
+    url: String,
+    timeout: Duration,
+  ) -> Result<(), reqwest::Error> {
+    let client = reqwest::Client::builder().timeout(timeout).build()?;
+    self
+      .inner
+      .upstream_clients
+      .write()
+      .await
+      .insert(url, client);
+    Ok(())
   }
 
   /// Resolve through a last-resort fallback cache without using route cache,
@@ -487,11 +511,15 @@ impl Router {
     group: &[String],
   ) -> (Result<RaceResult, RaceGroupError>, u32) {
     let auth_snapshot = self.inner.upstream_auth.read().await.clone();
+    let clients_snapshot = self.inner.upstream_clients.read().await.clone();
     let mut handles = FuturesUnordered::new();
     for upstream in group {
       let upstream = upstream.clone();
       let store_hash = store_hash.to_string();
-      let client = self.inner.client.clone();
+      let client = clients_snapshot
+        .get(&upstream)
+        .cloned()
+        .unwrap_or_else(|| self.inner.client.clone());
       let s3 = self.inner.s3.clone();
       let gate = self.upstream_gate(&upstream);
       let auth = auth_snapshot.get(&upstream).cloned();
@@ -789,10 +817,15 @@ impl Router {
         .ok_or(RouterError::NotFound)?
     } else {
       let auth = self.inner.upstream_auth.read().await.get(upstream).cloned();
-      let mut req = self
+      let client = self
         .inner
-        .client
-        .get(format!("{upstream}/{store_hash}.narinfo"));
+        .upstream_clients
+        .read()
+        .await
+        .get(upstream)
+        .cloned()
+        .unwrap_or_else(|| self.inner.client.clone());
+      let mut req = client.get(format!("{upstream}/{store_hash}.narinfo"));
       if let Some((user, pass)) = auth {
         req = req.basic_auth(user, pass);
       }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,4 +1,7 @@
-use std::{collections::BTreeMap, sync::Arc};
+use std::{
+  collections::{BTreeMap, HashMap},
+  sync::Arc,
+};
 
 use axum::{
   Router as AxumRouter,
@@ -26,8 +29,15 @@ pub struct AppState {
   upstreams:      Vec<UpstreamConfig>,
   fallback_cache: Option<UpstreamConfig>,
   s3:             S3ClientPool,
-  client:         reqwest::Client,
+  nar_clients:    HashMap<String, reqwest::Client>,
+  default_client: reqwest::Client,
   cache_priority: i32,
+}
+
+impl AppState {
+  fn nar_client(&self, url: &str) -> &reqwest::Client {
+    self.nar_clients.get(url).unwrap_or(&self.default_client)
+  }
 }
 
 pub struct AppConfig {
@@ -67,6 +77,29 @@ pub fn app(
   {
     s3.register(upstream.url.clone(), config.clone());
   }
+
+  let mut nar_clients = HashMap::new();
+  for upstream in &upstreams {
+    let timeout = upstream.nar_timeout.as_ref().map_or(read_timeout, |t| t.0);
+    nar_clients.insert(
+      upstream.url.clone(),
+      reqwest::Client::builder().read_timeout(timeout).build()?,
+    );
+  }
+  if let Some(upstream) = &fallback_cache
+    && !nar_clients.contains_key(&upstream.url)
+  {
+    let timeout = upstream.nar_timeout.as_ref().map_or(read_timeout, |t| t.0);
+    nar_clients.insert(
+      upstream.url.clone(),
+      reqwest::Client::builder().read_timeout(timeout).build()?,
+    );
+  }
+
+  let default_client = reqwest::Client::builder()
+    .read_timeout(read_timeout)
+    .build()?;
+
   let state = AppState {
     router,
     prober,
@@ -74,9 +107,8 @@ pub fn app(
     upstreams,
     fallback_cache,
     s3,
-    client: reqwest::Client::builder()
-      .read_timeout(read_timeout)
-      .build()?,
+    nar_clients,
+    default_client,
     cache_priority,
   };
   Ok(
@@ -184,7 +216,7 @@ async fn narinfo(
           .into_response();
       }
       proxy(
-        &state.client,
+        state.nar_client(&result.url),
         req.method().clone(),
         req.headers(),
         format!("{}{}", result.url, req.uri().path()),
@@ -239,7 +271,7 @@ async fn nar(
   if let Ok(Some(entry)) = state.db.get_route_by_nar_url(&nar_url).await
     && entry.is_valid()
     && let Some(resp) = try_nar_upstream(
-      &state.client,
+      state.nar_client(&entry.upstream_url),
       &state.s3,
       req.method().clone(),
       req.headers(),
@@ -264,7 +296,7 @@ async fn nar(
   for (_priority, group) in by_priority {
     for h in group {
       if let Some(resp) = try_nar_upstream(
-        &state.client,
+        state.nar_client(&h.url),
         &state.s3,
         req.method().clone(),
         req.headers(),
@@ -280,7 +312,7 @@ async fn nar(
   }
   if let Some(fallback) = &state.fallback_cache
     && let Some(resp) = try_nar_upstream(
-      &state.client,
+      state.nar_client(&fallback.url),
       &state.s3,
       req.method().clone(),
       req.headers(),
@@ -325,7 +357,7 @@ async fn try_fallback_narinfo(
       }
       Some(
         proxy(
-          &state.client,
+          state.nar_client(&result.url),
           req.method().clone(),
           req.headers(),
           format!("{}{}", result.url, req.uri().path()),

--- a/ncro/src/cli.rs
+++ b/ncro/src/cli.rs
@@ -159,6 +159,11 @@ pub async fn run() -> anyhow::Result<()> {
     router
       .set_upstream_filters(upstream.url.clone(), upstream.filters.clone())
       .await;
+    if let Some(timeout) = &upstream.narinfo_timeout {
+      router
+        .set_upstream_narinfo_timeout(upstream.url.clone(), timeout.0)
+        .await?;
+    }
   }
   if cfg.fallback_cache.enabled {
     let upstream = &cfg.fallback_cache.upstream;
@@ -178,6 +183,11 @@ pub async fn run() -> anyhow::Result<()> {
           upstream.password.clone(),
         )
         .await;
+    }
+    if let Some(timeout) = &upstream.narinfo_timeout {
+      router
+        .set_upstream_narinfo_timeout(upstream.url.clone(), timeout.0)
+        .await?;
     }
   }
 


### PR DESCRIPTION
Alas, I have to break the blessed 200 commits & v2.2.2  combo but you gotta do what you gotta do... Adds support for per-upstream timeout settings for both narinfo and NAR file requests, which leverages ncro's position as a proxy and allows graunlar control over how long the server waits for responses from each upstream cache. Comes with a tiny refactor of the handling of HTTP clients to enable these per-upstream timeouts.