### PR TITLE
Add narinfo URL rewrite modes

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -16,6 +16,7 @@ url      = "https://nix-community.cachix.org"
 # Optional per-upstream timeout overrides. When set, these override the global
 # timeouts for this upstream only.
 #
+# nar_url_mode    = "keep" # keep | to_self | to_upstream
 # narinfo_timeout = "10s"  # overrides the router's race timeout for narinfo
 # nar_timeout     = "60s"  # overrides the server's read_timeout for NAR streams
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -314,7 +314,7 @@ impl<'de> Deserialize<'de> for HumanDuration {
   }
 }
 
-#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum FilterAction {
   #[default]
@@ -330,6 +330,18 @@ pub enum FilterField {
   StorePath,
   Reference,
   Deriver,
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum NarUrlMode {
+  /// Return the upstream narinfo `URL:` line unchanged.
+  #[default]
+  Keep,
+  /// Rewrite `URL:` to a relative path so Nix fetches NARs through NCRO.
+  ToSelf,
+  /// Rewrite `URL:` to an absolute URL rooted at the selected upstream.
+  ToUpstream,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
@@ -361,6 +373,8 @@ pub struct UpstreamConfig {
   /// fetched. Deny rules reject immediately; if any allow rules exist,
   /// at least one must match.
   pub filters:         Vec<FilterRule>,
+  /// Controls how the narinfo `URL:` field is returned to clients.
+  pub nar_url_mode:    NarUrlMode,
   /// Optional per-upstream timeout for narinfo HEAD races and GET fetches.
   /// When unset, the router's global race timeout is used.
   pub narinfo_timeout: Option<HumanDuration>,

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -8,7 +8,14 @@ use chrono::Utc;
 use dashmap::{DashMap, mapref::entry::Entry};
 use futures_util::{StreamExt, stream::FuturesUnordered};
 use moka::future::Cache as MokaCache;
-use ncro_config::{FilterAction, FilterField, FilterRule};
+use ncro_config::{
+  FilterAction,
+  FilterField,
+  FilterRule,
+  NarUrlMode,
+  S3Config,
+  UpstreamConfig,
+};
 use ncro_db::{Db, DbError, RouteEntry};
 use ncro_health::{Prober, Status};
 use ncro_narinfo::{NarInfo, NarInfoError, parse_public_key};
@@ -34,6 +41,59 @@ pub enum RouterError {
   ParseNarinfo(#[from] NarInfoError),
   #[error(transparent)]
   Db(#[from] DbError),
+}
+
+#[derive(Debug, Error)]
+pub enum UpstreamRegistrationError {
+  #[error("invalid upstream public key: {0}")]
+  PublicKey(#[from] NarInfoError),
+  #[error("build upstream HTTP client: {0}")]
+  HttpClient(#[from] reqwest::Error),
+}
+
+pub trait RouterUpstream {
+  fn url(&self) -> &str;
+  fn public_key(&self) -> &str;
+  fn username(&self) -> &str;
+  fn password(&self) -> Option<&str>;
+  fn filters(&self) -> &[FilterRule];
+  fn nar_url_mode(&self) -> NarUrlMode;
+  fn narinfo_timeout(&self) -> Option<Duration>;
+  fn s3(&self) -> Option<&S3Config>;
+}
+
+impl RouterUpstream for UpstreamConfig {
+  fn url(&self) -> &str {
+    &self.url
+  }
+
+  fn public_key(&self) -> &str {
+    &self.public_key
+  }
+
+  fn username(&self) -> &str {
+    &self.username
+  }
+
+  fn password(&self) -> Option<&str> {
+    self.password.as_deref()
+  }
+
+  fn filters(&self) -> &[FilterRule] {
+    &self.filters
+  }
+
+  fn nar_url_mode(&self) -> NarUrlMode {
+    self.nar_url_mode
+  }
+
+  fn narinfo_timeout(&self) -> Option<Duration> {
+    self.narinfo_timeout.as_ref().map(|timeout| timeout.0)
+  }
+
+  fn s3(&self) -> Option<&S3Config> {
+    self.s3.as_ref()
+  }
 }
 
 #[derive(Debug, Clone)]
@@ -69,6 +129,7 @@ struct RouterInner {
   upstream_keys:            RwLock<HashMap<String, String>>,
   upstream_auth:            RwLock<HashMap<String, (String, Option<String>)>>,
   upstream_filters:         RwLock<HashMap<String, Vec<FilterRule>>>,
+  upstream_nar_url_modes:   RwLock<HashMap<String, NarUrlMode>>,
   inflight:                 DashMap<String, Arc<Mutex<()>>>,
   lru:                      MokaCache<String, Arc<ResolveResult>>,
   miss_lru:                 MokaCache<String, ()>,
@@ -155,6 +216,7 @@ impl Router {
         upstream_keys: RwLock::new(HashMap::new()),
         upstream_auth: RwLock::new(HashMap::new()),
         upstream_filters: RwLock::new(HashMap::new()),
+        upstream_nar_url_modes: RwLock::new(HashMap::new()),
         inflight: DashMap::new(),
         lru: MokaCache::builder()
           .max_capacity(1024)
@@ -177,9 +239,60 @@ impl Router {
 
   /// # Errors
   ///
+  /// Returns [`UpstreamRegistrationError`] if the upstream public key is
+  /// invalid or a per-upstream HTTP client cannot be built.
+  pub async fn register_upstream(
+    &self,
+    upstream: &(impl RouterUpstream + Sync + ?Sized),
+  ) -> Result<(), UpstreamRegistrationError> {
+    if let Some(s3) = upstream.s3() {
+      self
+        .inner
+        .s3
+        .register(upstream.url().to_string(), s3.clone());
+    }
+    if !upstream.public_key().is_empty() {
+      self
+        .register_upstream_key(
+          upstream.url().to_string(),
+          upstream.public_key().to_string(),
+        )
+        .await?;
+    }
+    if !upstream.username().is_empty() {
+      self
+        .register_upstream_auth(
+          upstream.url().to_string(),
+          upstream.username().to_string(),
+          upstream.password().map(str::to_string),
+        )
+        .await;
+    }
+    self
+      .register_upstream_filters(
+        upstream.url().to_string(),
+        upstream.filters().to_vec(),
+      )
+      .await;
+    self
+      .register_upstream_nar_url_mode(
+        upstream.url().to_string(),
+        upstream.nar_url_mode(),
+      )
+      .await;
+    if let Some(timeout) = upstream.narinfo_timeout() {
+      self
+        .register_upstream_narinfo_timeout(upstream.url().to_string(), timeout)
+        .await?;
+    }
+    Ok(())
+  }
+
+  /// # Errors
+  ///
   /// Returns [`NarInfoError`] if `public_key` is not in valid `name:base64`
   /// Nix format.
-  pub async fn set_upstream_key(
+  async fn register_upstream_key(
     &self,
     url: String,
     public_key: String,
@@ -195,7 +308,7 @@ impl Router {
   }
 
   /// Register HTTP Basic Auth credentials for an upstream URL.
-  pub async fn set_upstream_auth(
+  async fn register_upstream_auth(
     &self,
     url: String,
     username: String,
@@ -214,6 +327,14 @@ impl Router {
     url: String,
     filters: Vec<FilterRule>,
   ) {
+    self.register_upstream_filters(url, filters).await;
+  }
+
+  async fn register_upstream_filters(
+    &self,
+    url: String,
+    filters: Vec<FilterRule>,
+  ) {
     if filters.is_empty() {
       return;
     }
@@ -225,12 +346,20 @@ impl Router {
       .insert(url, filters);
   }
 
-  pub fn register_s3_upstream(
+  async fn register_upstream_nar_url_mode(
     &self,
-    upstream: String,
-    config: ncro_config::S3Config,
+    url: String,
+    mode: NarUrlMode,
   ) {
-    self.inner.s3.register(upstream, config);
+    if mode == NarUrlMode::Keep {
+      return;
+    }
+    self
+      .inner
+      .upstream_nar_url_modes
+      .write()
+      .await
+      .insert(url, mode);
   }
 
   /// Build and register a per-upstream HTTP client with a custom narinfo
@@ -240,7 +369,7 @@ impl Router {
   /// # Errors
   ///
   /// Returns an error if the per-upstream client cannot be built.
-  pub async fn set_upstream_narinfo_timeout(
+  async fn register_upstream_narinfo_timeout(
     &self,
     url: String,
     timeout: Duration,
@@ -269,11 +398,13 @@ impl Router {
   ) -> Result<ResolveResult, RouterError> {
     let start = Instant::now();
     let (body, _) = self.fetch_narinfo(upstream, store_hash).await?;
+    let narinfo_bytes =
+      self.response_narinfo_bytes(upstream, body.as_deref()).await;
     Ok(ResolveResult {
-      url:           upstream.to_string(),
-      latency_ms:    start.elapsed().as_secs_f64() * 1000.0,
-      cache_hit:     false,
-      narinfo_bytes: body,
+      url: upstream.to_string(),
+      latency_ms: start.elapsed().as_secs_f64() * 1000.0,
+      cache_hit: false,
+      narinfo_bytes,
     })
   }
 
@@ -353,7 +484,9 @@ impl Router {
       ncro_metrics::get().narinfo_cache_hits.inc();
       let mut result = (*cached).clone();
       if result.narinfo_bytes.is_none() {
-        result.narinfo_bytes = narinfo_bytes;
+        result.narinfo_bytes = self
+          .response_narinfo_bytes(&cached.url, narinfo_bytes.as_deref())
+          .await;
         self
           .inner
           .lru
@@ -387,11 +520,17 @@ impl Router {
       self.inner.db.set_route(&entry).await?;
     }
     ncro_metrics::get().narinfo_cache_hits.inc();
+    let narinfo_bytes = self
+      .response_narinfo_bytes(
+        &entry.upstream_url,
+        entry.narinfo_bytes.as_deref(),
+      )
+      .await;
     let result = ResolveResult {
-      url:           entry.upstream_url.clone(),
-      latency_ms:    entry.latency_ema,
-      cache_hit:     true,
-      narinfo_bytes: entry.narinfo_bytes.clone(),
+      url: entry.upstream_url.clone(),
+      latency_ms: entry.latency_ema,
+      cache_hit: true,
+      narinfo_bytes,
     };
     let arc = Arc::new(result.clone());
     self.inner.lru.insert(store_hash.to_string(), arc).await;
@@ -730,7 +869,9 @@ impl Router {
       url:           winner.url.clone(),
       latency_ms:    winner.latency_ms,
       cache_hit:     false,
-      narinfo_bytes: body.clone(),
+      narinfo_bytes: self
+        .response_narinfo_bytes(&winner.url, body.as_deref())
+        .await,
     };
     self
       .inner
@@ -848,6 +989,79 @@ impl Router {
     }
     Ok((Some(body), parsed))
   }
+
+  async fn response_narinfo_bytes(
+    &self,
+    upstream: &str,
+    body: Option<&[u8]>,
+  ) -> Option<Vec<u8>> {
+    let body = body?;
+    let mode = self
+      .inner
+      .upstream_nar_url_modes
+      .read()
+      .await
+      .get(upstream)
+      .copied()
+      .unwrap_or_default();
+    Some(rewrite_narinfo_url(body, upstream, mode))
+  }
+}
+
+fn rewrite_narinfo_url(
+  body: &[u8],
+  upstream: &str,
+  mode: NarUrlMode,
+) -> Vec<u8> {
+  if mode == NarUrlMode::Keep {
+    return body.to_vec();
+  }
+  let Ok(text) = std::str::from_utf8(body) else {
+    return body.to_vec();
+  };
+  let mut out = String::with_capacity(text.len() + upstream.len());
+  for line in text.split_inclusive('\n') {
+    let (line, newline) = line.strip_suffix('\n').map_or((line, ""), |line| {
+      line
+        .strip_suffix('\r')
+        .map_or((line, "\n"), |line| (line, "\r\n"))
+    });
+    if let Some(url) = line.strip_prefix("URL: ") {
+      out.push_str("URL: ");
+      out.push_str(&rewrite_nar_url_value(url, upstream, mode));
+    } else {
+      out.push_str(line);
+    }
+    out.push_str(newline);
+  }
+  out.into_bytes()
+}
+
+fn rewrite_nar_url_value(
+  url: &str,
+  upstream: &str,
+  mode: NarUrlMode,
+) -> String {
+  match mode {
+    NarUrlMode::Keep => url.to_string(),
+    NarUrlMode::ToSelf => relative_nar_url(url).to_string(),
+    NarUrlMode::ToUpstream => {
+      format!(
+        "{}/{}",
+        upstream.trim_end_matches('/'),
+        relative_nar_url(url).trim_start_matches('/')
+      )
+    },
+  }
+}
+
+fn relative_nar_url(url: &str) -> &str {
+  if let Some((_, rest)) = url.split_once("://")
+    && let Some((_, path)) = rest.split_once('/')
+  {
+    return path;
+  }
+  url.trim_start_matches('/')
 }
 
 fn filter_rule_matches(rule: &FilterRule, narinfo: &NarInfo) -> bool {
@@ -922,7 +1136,7 @@ mod tests {
   use std::{sync::Arc, time::Duration};
 
   use chrono::Utc;
-  use ncro_config::UpstreamConfig;
+  use ncro_config::{NarUrlMode, UpstreamConfig};
   use ncro_db::{Db, RouteEntry};
   use ncro_health::Prober;
   use tokio::{
@@ -940,6 +1154,7 @@ mod tests {
     Router,
     RouterTuning,
     filter_rule_matches,
+    rewrite_narinfo_url,
     store_path_name,
     wildcard_match,
   };
@@ -1082,6 +1297,33 @@ mod tests {
       },
       &narinfo,
     ));
+  }
+
+  #[test]
+  fn narinfo_url_to_self_preserves_path_and_query() {
+    let body = b"StorePath: /nix/store/abc-hello\nURL: https://cache.example/nar/abc.nar.xz?token=1\nNarHash: sha256:abc\nNarSize: 1\n";
+
+    let rewritten =
+      rewrite_narinfo_url(body, "https://cache.example", NarUrlMode::ToSelf);
+
+    let rewritten = String::from_utf8(rewritten).unwrap();
+    assert!(rewritten.contains("URL: nar/abc.nar.xz?token=1\n"));
+  }
+
+  #[test]
+  fn narinfo_url_to_upstream_uses_selected_upstream() {
+    let body = b"StorePath: /nix/store/abc-hello\nURL: /nar/abc.nar.xz\nNarHash: sha256:abc\nNarSize: 1\n";
+
+    let rewritten = rewrite_narinfo_url(
+      body,
+      "https://cache.example/root/",
+      NarUrlMode::ToUpstream,
+    );
+
+    let rewritten = String::from_utf8(rewritten).unwrap();
+    assert!(
+      rewritten.contains("URL: https://cache.example/root/nar/abc.nar.xz\n")
+    );
   }
 
   #[tokio::test]

--- a/ncro/src/cli.rs
+++ b/ncro/src/cli.rs
@@ -139,56 +139,12 @@ pub async fn run() -> anyhow::Result<()> {
   )?;
 
   for upstream in &cfg.upstreams {
-    if let Some(s3) = &upstream.s3 {
-      router.register_s3_upstream(upstream.url.clone(), s3.clone());
-    }
-    if !upstream.public_key.is_empty() {
-      router
-        .set_upstream_key(upstream.url.clone(), upstream.public_key.clone())
-        .await?;
-    }
-    if !upstream.username.is_empty() {
-      router
-        .set_upstream_auth(
-          upstream.url.clone(),
-          upstream.username.clone(),
-          upstream.password.clone(),
-        )
-        .await;
-    }
-    router
-      .set_upstream_filters(upstream.url.clone(), upstream.filters.clone())
-      .await;
-    if let Some(timeout) = &upstream.narinfo_timeout {
-      router
-        .set_upstream_narinfo_timeout(upstream.url.clone(), timeout.0)
-        .await?;
-    }
+    router.register_upstream(upstream).await?;
   }
   if cfg.fallback_cache.enabled {
-    let upstream = &cfg.fallback_cache.upstream;
-    if let Some(s3) = &upstream.s3 {
-      router.register_s3_upstream(upstream.url.clone(), s3.clone());
-    }
-    if !upstream.public_key.is_empty() {
-      router
-        .set_upstream_key(upstream.url.clone(), upstream.public_key.clone())
-        .await?;
-    }
-    if !upstream.username.is_empty() {
-      router
-        .set_upstream_auth(
-          upstream.url.clone(),
-          upstream.username.clone(),
-          upstream.password.clone(),
-        )
-        .await;
-    }
-    if let Some(timeout) = &upstream.narinfo_timeout {
-      router
-        .set_upstream_narinfo_timeout(upstream.url.clone(), timeout.0)
-        .await?;
-    }
+    router
+      .register_upstream(&cfg.fallback_cache.upstream)
+      .await?;
   }
 
   let (stop_tx, stop_rx) = tokio::sync::watch::channel(false);

--- a/nix/tests/e2e.nix
+++ b/nix/tests/e2e.nix
@@ -24,6 +24,7 @@
 
   cacheKey1Name = "ncro-e2e-cache1";
   cacheKey2Name = "ncro-e2e-cache2";
+  cacheKeyBadUrlName = "ncro-e2e-badurl-cache";
 
   # Shared NixOS module applied to every node.
   commonBase = {
@@ -91,6 +92,63 @@ in
           environment.NIX_SECRET_KEY_FILE = "/etc/nix/cache-key.sec";
           serviceConfig = {
             ExecStart = "${pkgs.nix-serve-ng}/bin/nix-serve --port 5000";
+            Restart = "on-failure";
+          };
+        };
+      };
+
+      # Static binary cache whose narinfo advertises an unreachable absolute
+      # NAR URL. The NAR itself is present under /nar/*, so a client only
+      # succeeds when NCRO rewrites the narinfo URL back through itself.
+      badurlcache = {
+        config,
+        pkgs,
+        ...
+      }: {
+        imports = [commonBase];
+
+        system.extraDependencies = [payload1];
+
+        systemd.services.setup-badurl-cache = {
+          description = "Generate static cache with deliberately bad narinfo URLs";
+          wantedBy = ["multi-user.target"];
+          before = ["badurl-cache.service"];
+          after = ["nix-daemon.service"];
+          requires = ["nix-daemon.service"];
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            ExecStart = pkgs.writeShellScript "setup-badurl-cache" ''
+              set -euo pipefail
+              mkdir -p /etc/nix /srv/badurl-cache
+              if [ ! -f /etc/nix/cache-key.sec ]; then
+                ${config.nix.package}/bin/nix-store \
+                  --generate-binary-cache-key "${cacheKeyBadUrlName}" \
+                  /etc/nix/cache-key.sec \
+                  /etc/nix/cache-key.pub
+              fi
+              chmod 644 /etc/nix/cache-key.pub /etc/nix/cache-key.sec
+
+              ${config.nix.package}/bin/nix copy \
+                --to 'file:///srv/badurl-cache?compression=xz&secret-key=/etc/nix/cache-key.sec' \
+                '${payload1}'
+
+              for narinfo in /srv/badurl-cache/*.narinfo; do
+                ${pkgs.gnused}/bin/sed -i \
+                  's#^URL: /*#URL: http://127.0.0.1:9/#' \
+                  "$narinfo"
+              done
+            '';
+          };
+        };
+
+        systemd.services.badurl-cache = {
+          description = "Serve static cache with bad narinfo URLs";
+          wantedBy = ["multi-user.target"];
+          after = ["setup-badurl-cache.service" "network.target"];
+          requires = ["setup-badurl-cache.service"];
+          serviceConfig = {
+            ExecStart = "${pkgs.python3}/bin/python3 -m http.server 5000 --directory /srv/badurl-cache"; # insane I know
             Restart = "on-failure";
           };
         };
@@ -250,6 +308,37 @@ in
           };
         };
       };
+
+      # Fourth ncro instance. Its upstream intentionally advertises broken NAR
+      # URLs, so nix copy only succeeds when nar_url_mode = "to_self" rewrites
+      # the client-visible narinfo URL back through NCRO.
+      rewriter = {
+        imports = [
+          self.nixosModules.ncro
+          commonBase
+        ];
+
+        nix.settings.trusted-substituters = ["http://localhost:8080"];
+
+        services.ncro = {
+          enable = true;
+          settings = {
+            server.listen = ":8080";
+            upstreams = [
+              {
+                url = "http://badurlcache:5000";
+                priority = 1;
+                nar_url_mode = "to_self";
+              }
+            ];
+
+            cache = {
+              ttl = "5m";
+              negative_ttl = "30s";
+            };
+          };
+        };
+      };
     };
 
     testScript = ''
@@ -286,6 +375,10 @@ in
       bincache1.wait_for_unit("nix-serve-ng.service")
       bincache1.wait_for_open_port(5000)
 
+      badurlcache.wait_for_unit("setup-badurl-cache.service")
+      badurlcache.wait_for_unit("badurl-cache.service")
+      badurlcache.wait_for_open_port(5000)
+
       bincache2.wait_for_unit("setup-cache.service")
       bincache2.wait_for_unit("harmonia.service")
       bincache2.wait_for_open_port(5000)
@@ -299,6 +392,9 @@ in
       filtered.wait_for_unit("ncro.service")
       filtered.wait_for_open_port(8080)
 
+      rewriter.wait_for_unit("ncro.service")
+      rewriter.wait_for_open_port(8080)
+
       with subtest("binary caches serve nix-cache-info"):
           for node, port in ((bincache1, 5000), (bincache2, 5000)):
               out = node.succeed(f"curl -sf http://localhost:{port}/nix-cache-info")
@@ -308,7 +404,8 @@ in
       with subtest("each cache backend serves its own payload narinfo directly"):
           cache1_public_key = bincache1.succeed("cat /etc/nix/cache-key.pub").strip()
           cache2_public_key = bincache2.succeed("cat /etc/nix/cache-key.pub").strip()
-          trusted_keys = f"{cache1_public_key} {cache2_public_key}"
+          badurl_public_key = badurlcache.succeed("cat /etc/nix/cache-key.pub").strip()
+          trusted_keys = f"{cache1_public_key} {cache2_public_key} {badurl_public_key}"
 
           out1 = bincache1.succeed(f"curl -sf http://localhost:5000/{hash1}.narinfo")
           assert "StorePath" in out1, \
@@ -363,6 +460,24 @@ in
           )
           host.succeed(f"test -f {payload1_path}/data")
           host.succeed(f"grep -q 'nix-serve-ng' {payload1_path}/data")
+
+      with subtest("nar_url_mode to_self rewrites bad upstream nar URL"):
+          upstream_narinfo = badurlcache.succeed(f"curl -sf http://localhost:5000/{hash1}.narinfo")
+          assert "URL: http://127.0.0.1:9/nar/" in upstream_narinfo, \
+              f"badurlcache did not advertise unreachable absolute NAR URL: {upstream_narinfo!r}"
+
+          rewritten_narinfo = rewriter.succeed(f"curl -sf http://localhost:8080/{hash1}.narinfo")
+          assert "URL: nar/" in rewritten_narinfo, \
+              f"rewriter ncro did not rewrite NAR URL to relative path: {rewritten_narinfo!r}"
+          assert "127.0.0.1:9" not in rewritten_narinfo, \
+              f"rewriter ncro leaked unreachable upstream NAR URL: {rewritten_narinfo!r}"
+
+          rewriter.fail(f"nix store ls {payload1_path} 2>/dev/null")
+          rewriter.succeed(
+              f"nix copy --from http://localhost:8080 --extra-trusted-public-keys '{trusted_keys}' {payload1_path}"
+          )
+          rewriter.succeed(f"test -f {payload1_path}/data")
+          rewriter.succeed(f"grep -q 'nix-serve-ng' {payload1_path}/data")
 
       with subtest("nix copy payload2 (harmonia) through host ncro"):
           host.fail(f"nix store ls {payload2_path} 2>/dev/null")


### PR DESCRIPTION
I was thinking maybe we'd implement more "transparent" proxying capabilities in the same line as selector4nix, another project in the same domain that caught my eye.

Consequently ncro now supports a per-upstream `nar_url_mode` setting. The default `keep` mode preserves existing behavior. `to_self` rewrites the narinfo `URL:` value to a relative path so NAR downloads are routed back through NCRO. `to_upstream` rewrites the value to an absolute URL rooted at the selected upstream. Rewriting happens only after the upstream narinfo has been fetched, parsed, filtered, and signature-verified, so verification still happens against the upstream’s original signed content. The route database continues to store the original upstream URL path for stable NAR lookup. tl;dr: This PR adds:

- Add per-upstream timeout overrides for narinfo requests and NAR streaming
- Add configurable narinfo `URL:` rewrite modes

Also for nerds, router-side upstream setup is now routed through a `RouterUpstream` abstraction and `Router::register_upstream(...)`. This hopefully avoids continuing to grow one-off startup setters for every new upstream attribute, and keeps future upstream-level features easier to add without duplicating wiring in the CLI. Will I use it? Probably not. Do I like it? Yes.

Also credit where credit is due. This PR was inspired by the substituter-proxying ideas around per-substituter behavior and narinfo URL routing of <https://github.com/StarryReverie/selector4nix>.

