### PR TITLE
Support multiple upstream public keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2227,8 +2227,10 @@ dependencies = [
 name = "ncro-router"
 version = "2.2.2"
 dependencies = [
+ "base64",
  "chrono",
  "dashmap",
+ "ed25519-dalek",
  "futures-util",
  "moka",
  "ncro-config",
@@ -2237,6 +2239,7 @@ dependencies = [
  "ncro-metrics",
  "ncro-narinfo",
  "ncro-s3",
+ "rand 0.10.1",
  "reqwest",
  "thiserror 2.0.18",
  "tokio",

--- a/README.md
+++ b/README.md
@@ -177,6 +177,12 @@ url = "https://cache.nixos.org"
 priority = 10 # lower = preferred on latency ties (within 10%)
 public_key = "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
 
+# Pull-through caches can accept more than one narinfo signer.
+# public_keys = [
+#   "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=",
+#   "origin-cache-1:...",
+# ]
+
 [[upstreams]]
 url = "https://nix-community.cachix.org"
 priority = 20
@@ -312,9 +318,9 @@ public_key = "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
 ```
 
 The fallback cache accepts the same connection-related fields as an upstream:
-`url`, `public_key`, `username`, `password`, and Nix-style `s3://` URLs. It is
-not a member of `[[upstreams]]`, and ncro deliberately keeps it out of normal
-router behavior:
+`url`, `public_key`, `public_keys`, `username`, `password`, and Nix-style
+`s3://` URLs. It is not a member of `[[upstreams]]`, and ncro deliberately keeps
+it out of normal router behavior:
 
 - It is not health probed and does not appear in `/health`.
 - It is not affected by upstream priority, discovery, cooldown, or filters.
@@ -440,8 +446,8 @@ On NixOS, set `services.ncro.netrcFile` to pass a netrc file into the service.
   };
 
   # Point Nix at the proxy. By default the module appends every configured
-  # upstream public_key, plus the fallback_cache public_key when fallback is
-  # enabled, to nix.settings.trusted-public-keys; set
+  # upstream public_key/public_keys, plus the fallback_cache public keys when
+  # fallback is enabled, to nix.settings.trusted-public-keys; set
   # services.ncro.addUpstreamPublicKeys = false to manage those keys yourself.
   # NOTE: ncro needs to be the *only* substituter if you wish to benefit
   # from its capabilities fully. If there are other substituters in your

--- a/config.example.toml
+++ b/config.example.toml
@@ -5,8 +5,13 @@ write_timeout = "30s"
 
 [[upstreams]]
 priority   = 10
-public_key = "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
 url        = "https://cache.nixos.org"
+public_key = "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+# Pull-through caches may need to accept multiple narinfo signers:
+# public_keys = [
+#   "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=",
+#   "origin-cache-1:...",
+# ]
 
 # Try without a public key.
 [[upstreams]]
@@ -33,12 +38,12 @@ url      = "https://nix-community.cachix.org"
 # Optional last-resort cache. Disabled by default. When enabled, this cache is
 # used only when the normal upstream set is unavailable, and is not part of
 # health probing, priority routing, discovery, filters, cooldown, or route DB
-# persistence. URL, public_key, username/password/password_file, and s3:// URLs
-# are accepted like regular upstreams.
+# persistence. URL, public_key/public_keys, username/password/password_file,
+# and s3:// URLs are accepted like regular upstreams.
 [fallback_cache]
 enabled    = false
-public_key = "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
 url        = "https://cache.nixos.org"
+public_key = "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
 
 [cache]
 db_path       = "/var/lib/ncro/routes.db"

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -268,6 +268,22 @@ mod tests {
   }
 
   #[test]
+  fn validates_upstream_public_keys_entries() -> Result<(), toml::de::Error> {
+    let cfg: Config = toml::from_str(
+      "[[upstreams]]\nurl = \"https://cache.example\"\npublic_keys = \
+       [\"missing-separator\"]\n",
+    )?;
+
+    let result = cfg.validate();
+
+    assert!(result.is_err(), "expected validation failure");
+    if let Err(err) = result {
+      assert!(err.to_string().contains("public_keys[0]"));
+    }
+    Ok(())
+  }
+
+  #[test]
   fn logging_level_accepts_tracing_filter_directives() -> Result<(), ConfigError>
   {
     let cfg: Config =
@@ -689,8 +705,13 @@ pub struct UpstreamConfig {
   /// this priority.
   pub priority:        i32,
   /// Nix-style `name:base64(key)` public key for narinfo signature
-  /// verification. Leave empty to skip verification.
+  /// verification. Leave empty to skip verification unless `public_keys` is
+  /// set.
   pub public_key:      String,
+  /// Additional Nix-style public keys accepted for narinfo signature
+  /// verification. Useful for pull-through caches that may serve narinfos
+  /// signed by an origin cache key.
+  pub public_keys:     Vec<String>,
   /// HTTP Basic Auth username. Requests are made without authentication
   /// when empty.
   pub username:        String,
@@ -722,6 +743,7 @@ impl fmt::Debug for UpstreamConfig {
       .field("url", &self.url)
       .field("priority", &self.priority)
       .field("public_key", &self.public_key)
+      .field("public_keys", &self.public_keys)
       .field("username", &self.username)
       .field("password", &self.password.as_ref().map(|_| "<redacted>"))
       .field("password_file", &self.password_file)
@@ -1156,10 +1178,14 @@ fn validate_upstream(
       upstream.url
     ))
   })?;
-  if !upstream.public_key.is_empty() && !upstream.public_key.contains(':') {
-    return Err(ConfigError::Validation(format!(
-      "{label}: public_key must be in 'name:base64(key)' Nix format"
-    )));
+  if !upstream.public_key.is_empty() {
+    validate_nix_public_key(
+      &upstream.public_key,
+      &format!("{label}: public_key"),
+    )?;
+  }
+  for (i, public_key) in upstream.public_keys.iter().enumerate() {
+    validate_nix_public_key(public_key, &format!("{label}: public_keys[{i}]"))?;
   }
   if upstream.password.is_some() && upstream.password_file.is_some() {
     return Err(ConfigError::Validation(format!(
@@ -1172,6 +1198,18 @@ fn validate_upstream(
         "{label}.filters[{j}]: pattern is empty"
       )));
     }
+  }
+  Ok(())
+}
+
+fn validate_nix_public_key(
+  public_key: &str,
+  label: &str,
+) -> Result<(), ConfigError> {
+  if public_key.is_empty() || !public_key.contains(':') {
+    return Err(ConfigError::Validation(format!(
+      "{label} must be in 'name:base64(key)' Nix format"
+    )));
   }
   Ok(())
 }

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -23,5 +23,10 @@ thiserror.workspace    = true
 tokio                  = { workspace = true, features = [ "macros", "sync", "time", "rt" ] }
 tracing.workspace      = true
 
+[dev-dependencies]
+base64.workspace        = true
+ed25519-dalek.workspace = true
+rand.workspace          = true
+
 [lints]
 workspace = true

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -54,6 +54,7 @@ pub enum UpstreamRegistrationError {
 pub trait RouterUpstream {
   fn url(&self) -> &str;
   fn public_key(&self) -> &str;
+  fn public_keys(&self) -> &[String];
   fn username(&self) -> &str;
   fn password(&self) -> Option<&str>;
   fn filters(&self) -> &[FilterRule];
@@ -69,6 +70,10 @@ impl RouterUpstream for UpstreamConfig {
 
   fn public_key(&self) -> &str {
     &self.public_key
+  }
+
+  fn public_keys(&self) -> &[String] {
+    &self.public_keys
   }
 
   fn username(&self) -> &str {
@@ -126,7 +131,7 @@ struct RouterInner {
   client:                   reqwest::Client,
   upstream_clients:         RwLock<HashMap<String, reqwest::Client>>,
   s3:                       S3ClientPool,
-  upstream_keys:            RwLock<HashMap<String, String>>,
+  upstream_keys:            RwLock<HashMap<String, Vec<String>>>,
   upstream_auth:            RwLock<HashMap<String, (String, Option<String>)>>,
   upstream_filters:         RwLock<HashMap<String, Vec<FilterRule>>>,
   upstream_nar_url_modes:   RwLock<HashMap<String, NarUrlMode>>,
@@ -250,7 +255,11 @@ impl Router {
       self.inner.s3.register(url.clone(), s3.clone());
     }
     self
-      .register_upstream_key(url.clone(), upstream.public_key().to_string())
+      .register_upstream_keys(
+        url.clone(),
+        upstream.public_key().to_string(),
+        upstream.public_keys().to_vec(),
+      )
       .await?;
     self
       .register_upstream_auth(
@@ -273,19 +282,23 @@ impl Router {
 
   /// # Errors
   ///
-  /// Returns [`NarInfoError`] if `public_key` is not in valid `name:base64`
-  /// Nix format.
-  async fn register_upstream_key(
+  /// Returns [`NarInfoError`] if any public key is not in valid
+  /// `name:base64` Nix format.
+  async fn register_upstream_keys(
     &self,
     url: String,
     public_key: String,
+    public_keys: Vec<String>,
   ) -> Result<(), NarInfoError> {
+    let keys = normalized_public_keys(public_key, public_keys);
+    for key in &keys {
+      parse_public_key(key)?;
+    }
     let mut map = self.inner.upstream_keys.write().await;
-    if public_key.is_empty() {
+    if keys.is_empty() {
       map.remove(&url);
     } else {
-      parse_public_key(&public_key)?;
-      map.insert(url, public_key);
+      map.insert(url, keys);
     }
     Ok(())
   }
@@ -944,8 +957,9 @@ impl Router {
       resp.bytes().await?.to_vec()
     };
     let parsed = NarInfo::parse(body.as_slice())?;
-    if let Some(pubkey) = self.inner.upstream_keys.read().await.get(upstream)
-      && !parsed.verify(pubkey).unwrap_or(false)
+    if let Some(public_keys) =
+      self.inner.upstream_keys.read().await.get(upstream)
+      && !narinfo_verifies_any_key(&parsed, public_keys)
     {
       tracing::warn!(
         upstream,
@@ -972,6 +986,27 @@ impl Router {
     }
     Some(rewrite_narinfo_url(body, upstream, mode))
   }
+}
+
+fn normalized_public_keys(
+  public_key: String,
+  public_keys: Vec<String>,
+) -> Vec<String> {
+  let mut keys =
+    Vec::with_capacity(usize::from(!public_key.is_empty()) + public_keys.len());
+  if !public_key.is_empty() {
+    keys.push(public_key);
+  }
+  keys.extend(public_keys);
+  keys.sort();
+  keys.dedup();
+  keys
+}
+
+fn narinfo_verifies_any_key(narinfo: &NarInfo, public_keys: &[String]) -> bool {
+  public_keys
+    .iter()
+    .any(|public_key| narinfo.verify(public_key).unwrap_or(false))
 }
 
 fn rewrite_narinfo_url(
@@ -1101,10 +1136,13 @@ mod tests {
   #![expect(clippy::unwrap_used, reason = "Fine in tests")]
   use std::{sync::Arc, time::Duration};
 
+  use base64::{Engine as _, engine::general_purpose::STANDARD};
   use chrono::Utc;
+  use ed25519_dalek::{Signer, SigningKey};
   use ncro_config::{NarUrlMode, UpstreamConfig};
   use ncro_db::{Db, RouteEntry};
   use ncro_health::Prober;
+  use rand::RngExt;
   use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::TcpListener,
@@ -1120,6 +1158,7 @@ mod tests {
     Router,
     RouterTuning,
     filter_rule_matches,
+    narinfo_verifies_any_key,
     rewrite_narinfo_url,
     store_path_name,
     wildcard_match,
@@ -1222,6 +1261,27 @@ mod tests {
     format!("http://{addr}")
   }
 
+  fn signed_narinfo(key_name: &str) -> (NarInfo, String) {
+    let mut key_bytes = [0_u8; 32];
+    rand::rng().fill(&mut key_bytes);
+    let signing = SigningKey::from_bytes(&key_bytes);
+    let mut narinfo = NarInfo {
+      store_path: "/nix/store/abc123-test".to_string(),
+      nar_hash: "sha256:abc".to_string(),
+      nar_size: 12,
+      references: vec![],
+      ..Default::default()
+    };
+    let sig = signing.sign(narinfo.fingerprint().as_bytes());
+    narinfo.sig =
+      vec![format!("{key_name}:{}", STANDARD.encode(sig.to_bytes()))];
+    let public_key = format!(
+      "{key_name}:{}",
+      STANDARD.encode(signing.verifying_key().to_bytes())
+    );
+    (narinfo, public_key)
+  }
+
   #[test]
   fn extracts_store_path_name() {
     assert_eq!(
@@ -1236,6 +1296,18 @@ mod tests {
     assert!(wildcard_match("*-source", "foo-source"));
     assert!(wildcard_match("*zed*", "my-zedless-package"));
     assert!(!wildcard_match("zedless", "zedless-0.1.0"));
+  }
+
+  #[test]
+  fn narinfo_verification_accepts_any_configured_public_key() {
+    let (narinfo, matching_key) = signed_narinfo("origin");
+    let (_, other_key) = signed_narinfo("other");
+
+    assert!(narinfo_verifies_any_key(&narinfo, &[
+      other_key.clone(),
+      matching_key
+    ]));
+    assert!(!narinfo_verifies_any_key(&narinfo, &[other_key]));
   }
 
   #[test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,12 @@ instead of `password` when the upstream Basic Auth password should be read from
 a secret file; one trailing newline is ignored, and `password` plus
 `password_file` is rejected.
 
+Use `public_keys` when an upstream may serve narinfos signed by more than one
+cache key, such as a pull-through cache that can return both locally signed
+narinfos and narinfos signed by `cache.nixos.org`. `public_key` remains valid as
+shorthand for a single accepted signing key. When both are set, ncro accepts
+signatures from either field.
+
 Upstream filters support `allow` and `deny` rules over narinfo fields. The
 available fields are `name`, `store_path`, `reference`, and `deriver`; patterns
 use `*` wildcards. Deny rules always win. If any allow rules are configured for
@@ -39,9 +45,9 @@ are registered as upstreams. The default `any` registers all routable addresses
 `fallback_cache` defines an optional last-resort backend. It is disabled by
 default and defaults to `https://cache.nixos.org` when enabled. The fallback
 cache accepts the same connection fields as an upstream (`url`, `public_key`,
-`username`, `password`, `password_file`, and `s3://` URLs), but it is not part
-of normal upstream routing. It is only used after normal candidates are
-unavailable and its responses are not persisted as route winners.
+`public_keys`, `username`, `password`, `password_file`, and `s3://` URLs), but
+it is not part of normal upstream routing. It is only used after normal
+candidates are unavailable and its responses are not persisted as route winners.
 
 `logging.level` is a tracing filter directive. Use a single level such as
 `debug`, `info`, `warn`, or `error` for global filtering, or a directive list

--- a/docs/install.md
+++ b/docs/install.md
@@ -201,7 +201,7 @@ nix-shell -p hello \
 > [!TIP]
 > For persistent setup, add the URL to `nix.settings.substituters` and add every
 > upstream cache signing key to `nix.settings.trusted-public-keys`. The NixOS
-> module does this for configured `public_key` values unless
+> module does this for configured `public_key` and `public_keys` values unless
 > `services.ncro.addUpstreamPublicKeys` is disabled.
 
 ## Verification

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
       s3 = pkgs.callPackage ./nix/tests/s3.nix {inherit self;};
       netrc = pkgs.callPackage ./nix/tests/netrc.nix {inherit self;};
       socket-activation = pkgs.callPackage ./nix/tests/socket-activation.nix {inherit self;};
+      public-keys = pkgs.callPackage ./nix/tests/public-keys.nix {inherit self;};
     });
 
     # Provides the default formatter for 'nix fmt'.

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -28,16 +28,29 @@
     then "0.0.0.0${raw}"
     else raw;
 
-  fallbackPublicKeys =
-    optional
-    (cfg.settings.fallback_cache.enabled or false)
-    (cfg.settings.fallback_cache.public_key or "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=");
+  publicKeysFor = upstream:
+    optional ((upstream.public_key or "") != "") upstream.public_key
+    ++ (upstream.public_keys or []);
 
-  upstreamPublicKeys = lib.pipe ((cfg.settings.upstreams or []) ++ fallbackPublicKeys) [
+  fallbackPublicKeys =
+    if cfg.settings.fallback_cache.enabled or false
+    then
+      publicKeysFor (
+        cfg.settings.fallback_cache
+        // {
+          public_key =
+            cfg.settings.fallback_cache.public_key
+              or "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=";
+        }
+      )
+    else [];
+
+  upstreamPublicKeys = lib.pipe ((cfg.settings.upstreams or []) ++ [fallbackPublicKeys]) [
     (builtins.map (upstream:
       if builtins.isAttrs upstream
-      then upstream.public_key or ""
+      then publicKeysFor upstream
       else upstream))
+    lib.flatten
     (builtins.filter (key: key != ""))
     lib.unique
   ];
@@ -49,7 +62,7 @@ in {
       type = bool;
       default = true;
       description = ''
-        Append non-empty upstream public_key values from {option}`services.ncro.settings`
+        Append non-empty upstream public_key and public_keys values from {option}`services.ncro.settings`
         to {option}`nix.settings.trusted-public-keys`.
 
         This keeps Nix client signature validation aligned with the upstream

--- a/nix/tests/public-keys.nix
+++ b/nix/tests/public-keys.nix
@@ -1,0 +1,59 @@
+{
+  pkgs,
+  self,
+}:
+pkgs.testers.runNixOSTest {
+  name = "ncro-public-keys";
+
+  nodes.machine = {
+    imports = [self.nixosModules.ncro];
+
+    virtualisation.memorySize = 512;
+    networking.firewall.enable = false;
+
+    services.ncro = {
+      enable = true;
+      # The test only needs the module-generated config and nix.conf. Avoid
+      # building or starting the real proxy.
+      package = pkgs.writeShellScriptBin "ncro" ''
+        exec ${pkgs.coreutils}/bin/sleep infinity
+      '';
+      settings = {
+        upstreams = [
+          {
+            url = "https://pull-through.example";
+            public_key = "pull-through-1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+            public_keys = [
+              "origin-1:AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE="
+              "cache-1:AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI="
+            ];
+          }
+        ];
+
+        fallback_cache = {
+          enabled = true;
+          public_key = "fallback-1:AwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwM=";
+          public_keys = [
+            "fallback-origin-1:BAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ="
+          ];
+        };
+      };
+    };
+  };
+
+  testScript = ''
+    with subtest("nix trusts all configured upstream signing keys"):
+        machine.start()
+
+        nix_conf = machine.succeed("cat /etc/nix/nix.conf")
+        for key in [
+            "pull-through-1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+            "origin-1:AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=",
+            "cache-1:AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI=",
+            "fallback-1:AwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwM=",
+            "fallback-origin-1:BAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ=",
+        ]:
+            assert key in nix_conf, \
+                f"expected trusted-public-keys to include {key!r}; nix.conf was: {nix_conf!r}"
+  '';
+}


### PR DESCRIPTION
Adds support configuring multiple public keys per upstream cache as described in #44

Since ncro is as transparent and stateless as possible, this aims to be allowing verification of narinfos signed by more than one key (for example, when using pull-through caches) without stepping on our shoes. The NixOS module ensures all relevant keys are added to `trusted-public-keys`.