### PR TITLE
Avoid rounding errors in msec logging

### DIFF
--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -203,7 +203,7 @@ async fn narinfo(
         hash = hash,
         upstream = result.url,
         cache_hit = result.cache_hit,
-        latency_ms = result.latency_ms,
+        latency_ms = format_args!("{:.5}", result.latency_ms),
         "narinfo routed"
       );
       ncro_metrics::get()
@@ -341,7 +341,7 @@ async fn try_fallback_narinfo(
       tracing::warn!(
         hash,
         upstream = result.url,
-        latency_ms = result.latency_ms,
+        latency_ms = format_args!("{:.5}", result.latency_ms),
         "narinfo routed to fallback cache"
       );
       ncro_metrics::get()


### PR DESCRIPTION
Like latency_ms=30.257106999999998 or latency_ms=39.131350000000005