### PR TITLE
router: serve NAR bodies from a canonical store-hash path

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -682,9 +682,9 @@ pub enum FilterField {
 #[serde(rename_all = "snake_case")]
 pub enum NarUrlMode {
   /// Return the upstream narinfo `URL:` line unchanged.
-  #[default]
   Keep,
-  /// Rewrite `URL:` to a relative path so Nix fetches NARs through NCRO.
+  /// Rewrite `URL:` to a canonical `nar/<store-hash>` path served by NCRO.
+  #[default]
   ToSelf,
   /// Rewrite `URL:` to an absolute URL rooted at the selected upstream.
   ToUpstream,

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -29,18 +29,20 @@ pub enum DbError {
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct RouteEntry {
-  pub store_path:    String,
-  pub upstream_url:  String,
-  pub latency_ms:    f64,
-  pub latency_ema:   f64,
-  pub last_verified: DateTime<Utc>,
-  pub query_count:   u32,
-  pub failure_count: u32,
-  pub ttl:           DateTime<Utc>,
-  pub nar_hash:      String,
-  pub nar_size:      u64,
-  pub nar_url:       String,
-  pub narinfo_bytes: Option<Vec<u8>>,
+  pub store_path:       String,
+  pub upstream_url:     String,
+  pub latency_ms:       f64,
+  pub latency_ema:      f64,
+  pub last_verified:    DateTime<Utc>,
+  pub query_count:      u32,
+  pub failure_count:    u32,
+  pub ttl:              DateTime<Utc>,
+  pub nar_hash:         String,
+  pub nar_size:         u64,
+  pub nar_url:          String,
+  /// The upstream's own path, since `nar_url` is canonical.
+  pub upstream_nar_url: String,
+  pub narinfo_bytes:    Option<Vec<u8>>,
 }
 
 impl RouteEntry {
@@ -119,7 +121,7 @@ impl Db {
   ) -> Result<Option<RouteEntry>, DbError> {
     let row = sqlx::query(
             r"SELECT store_path, upstream_url, latency_ms, latency_ema, query_count, failure_count,
-                      last_verified, ttl, nar_hash, nar_size, nar_url, narinfo_bytes
+                      last_verified, ttl, nar_hash, nar_size, nar_url, upstream_nar_url, narinfo_bytes
                  FROM routes WHERE store_path = ?",
         )
         .bind(store_path)
@@ -137,7 +139,7 @@ impl Db {
   ) -> Result<Option<RouteEntry>, DbError> {
     let row = sqlx::query(
             r"SELECT store_path, upstream_url, latency_ms, latency_ema, query_count, failure_count,
-                      last_verified, ttl, nar_hash, nar_size, nar_url, narinfo_bytes
+                      last_verified, ttl, nar_hash, nar_size, nar_url, upstream_nar_url, narinfo_bytes
                  FROM routes WHERE nar_url = ? AND ttl > ?",
         )
         .bind(nar_url)
@@ -155,8 +157,8 @@ impl Db {
     sqlx::query(
             r"INSERT INTO routes
                (store_path, upstream_url, latency_ms, latency_ema, query_count, failure_count,
-                last_verified, ttl, nar_hash, nar_size, nar_url, narinfo_bytes)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                last_verified, ttl, nar_hash, nar_size, nar_url, upstream_nar_url, narinfo_bytes)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT(store_path) DO UPDATE SET
                  upstream_url = excluded.upstream_url,
                  latency_ms = excluded.latency_ms,
@@ -168,6 +170,7 @@ impl Db {
                  nar_hash = excluded.nar_hash,
                  nar_size = excluded.nar_size,
                  nar_url = excluded.nar_url,
+                 upstream_nar_url = excluded.upstream_nar_url,
                  narinfo_bytes = excluded.narinfo_bytes",
         )
         .bind(&entry.store_path)
@@ -181,6 +184,7 @@ impl Db {
         .bind(&entry.nar_hash)
         .bind(i64::try_from(entry.nar_size).unwrap_or(i64::MAX))
         .bind(&entry.nar_url)
+        .bind(&entry.upstream_nar_url)
         .bind(&entry.narinfo_bytes)
         .execute(&self.pool)
         .await?;
@@ -212,7 +216,7 @@ impl Db {
   ) -> Result<Vec<RouteEntry>, DbError> {
     let rows = sqlx::query(
             r"SELECT store_path, upstream_url, latency_ms, latency_ema, query_count, failure_count,
-                      last_verified, ttl, nar_hash, nar_size, nar_url, narinfo_bytes
+                      last_verified, ttl, nar_hash, nar_size, nar_url, upstream_nar_url, narinfo_bytes
                  FROM routes WHERE ttl > ? ORDER BY last_verified DESC LIMIT ?",
         )
         .bind(Utc::now().timestamp())
@@ -433,6 +437,13 @@ async fn migrate(pool: &SqlitePool) -> Result<(), DbError> {
   .execute(pool)
   .await?;
   add_column_if_missing(pool, "routes", "narinfo_bytes", "BLOB").await?;
+  add_column_if_missing(
+    pool,
+    "routes",
+    "upstream_nar_url",
+    "TEXT NOT NULL DEFAULT ''",
+  )
+  .await?;
   Ok(())
 }
 
@@ -441,26 +452,27 @@ fn row_to_route(row: &sqlx::sqlite::SqliteRow) -> Result<RouteEntry, DbError> {
   let failure_count = row.get::<i64, _>("failure_count");
   let nar_size = row.get::<i64, _>("nar_size");
   Ok(RouteEntry {
-    store_path:    row.get("store_path"),
-    upstream_url:  row.get("upstream_url"),
-    latency_ms:    row.get("latency_ms"),
-    latency_ema:   row.get("latency_ema"),
-    query_count:   u32::try_from(query_count).map_err(|_| {
+    store_path:       row.get("store_path"),
+    upstream_url:     row.get("upstream_url"),
+    latency_ms:       row.get("latency_ms"),
+    latency_ema:      row.get("latency_ema"),
+    query_count:      u32::try_from(query_count).map_err(|_| {
       DbError::InvalidData(format!("query_count out of range: {query_count}"))
     })?,
-    failure_count: u32::try_from(failure_count).map_err(|_| {
+    failure_count:    u32::try_from(failure_count).map_err(|_| {
       DbError::InvalidData(format!(
         "failure_count out of range: {failure_count}"
       ))
     })?,
-    last_verified: timestamp(row.get("last_verified"), "last_verified")?,
-    ttl:           timestamp(row.get("ttl"), "ttl")?,
-    nar_hash:      row.get("nar_hash"),
-    nar_size:      u64::try_from(nar_size).map_err(|_| {
+    last_verified:    timestamp(row.get("last_verified"), "last_verified")?,
+    ttl:              timestamp(row.get("ttl"), "ttl")?,
+    nar_hash:         row.get("nar_hash"),
+    nar_size:         u64::try_from(nar_size).map_err(|_| {
       DbError::InvalidData(format!("nar_size out of range: {nar_size}"))
     })?,
-    nar_url:       row.get("nar_url"),
-    narinfo_bytes: row.get("narinfo_bytes"),
+    nar_url:          row.get("nar_url"),
+    upstream_nar_url: row.get("upstream_nar_url"),
+    narinfo_bytes:    row.get("narinfo_bytes"),
   })
 }
 
@@ -496,18 +508,19 @@ mod tests {
     let db = Db::open(":memory:", 100, SLOW_STATEMENT_THRESHOLD).await?;
     let now = Utc::now();
     let entry = RouteEntry {
-      store_path:    "abc123".into(),
-      upstream_url:  "https://cache.nixos.org".into(),
-      latency_ms:    10.0,
-      latency_ema:   10.0,
-      last_verified: now,
-      query_count:   1,
-      failure_count: 0,
-      ttl:           now + chrono::Duration::hours(1),
-      nar_hash:      "sha256:abc".into(),
-      nar_size:      42,
-      nar_url:       "nar/abc.nar.xz".into(),
-      narinfo_bytes: None,
+      store_path:       "abc123".into(),
+      upstream_url:     "https://cache.nixos.org".into(),
+      latency_ms:       10.0,
+      latency_ema:      10.0,
+      last_verified:    now,
+      query_count:      1,
+      failure_count:    0,
+      ttl:              now + chrono::Duration::hours(1),
+      nar_hash:         "sha256:abc".into(),
+      nar_size:         42,
+      nar_url:          "nar/abc.nar.xz".into(),
+      upstream_nar_url: "nar/abc.nar.xz".into(),
+      narinfo_bytes:    None,
     };
     db.set_route(&entry).await?;
     let got = db
@@ -527,18 +540,19 @@ mod tests {
     let now = Utc::now();
     let bytes = b"StorePath: /nix/store/abc\n".to_vec();
     let entry = RouteEntry {
-      store_path:    "abc".into(),
-      upstream_url:  "https://cache.nixos.org".into(),
-      latency_ms:    1.0,
-      latency_ema:   1.0,
-      last_verified: now,
-      query_count:   1,
-      failure_count: 0,
-      ttl:           now + chrono::Duration::hours(1),
-      nar_hash:      "sha256:abc".into(),
-      nar_size:      26,
-      nar_url:       "nar/abc.nar".into(),
-      narinfo_bytes: Some(bytes.clone()),
+      store_path:       "abc".into(),
+      upstream_url:     "https://cache.nixos.org".into(),
+      latency_ms:       1.0,
+      latency_ema:      1.0,
+      last_verified:    now,
+      query_count:      1,
+      failure_count:    0,
+      ttl:              now + chrono::Duration::hours(1),
+      nar_hash:         "sha256:abc".into(),
+      nar_size:         26,
+      nar_url:          "nar/abc.nar".into(),
+      upstream_nar_url: "nar/abc.nar".into(),
+      narinfo_bytes:    Some(bytes.clone()),
     };
     db.set_route(&entry).await?;
     let got = db
@@ -554,18 +568,19 @@ mod tests {
     let db = Db::open(":memory:", 100, SLOW_STATEMENT_THRESHOLD).await?;
     let now = Utc::now();
     let entry = RouteEntry {
-      store_path:    "aaa".into(),
-      upstream_url:  "https://cache.nixos.org".into(),
-      latency_ms:    1.0,
-      latency_ema:   1.0,
-      last_verified: now,
-      query_count:   1,
-      failure_count: 0,
-      ttl:           now + chrono::Duration::hours(1),
-      nar_hash:      "sha256:x".into(),
-      nar_size:      1,
-      nar_url:       "nar/x.nar".into(),
-      narinfo_bytes: None,
+      store_path:       "aaa".into(),
+      upstream_url:     "https://cache.nixos.org".into(),
+      latency_ms:       1.0,
+      latency_ema:      1.0,
+      last_verified:    now,
+      query_count:      1,
+      failure_count:    0,
+      ttl:              now + chrono::Duration::hours(1),
+      nar_hash:         "sha256:x".into(),
+      nar_size:         1,
+      nar_url:          "nar/x.nar".into(),
+      upstream_nar_url: "nar/x.nar".into(),
+      narinfo_bytes:    None,
     };
     db.set_route(&entry).await?;
     let db = Arc::new(db);
@@ -603,18 +618,19 @@ mod tests {
         tokio::spawn(async move {
           let now = Utc::now();
           let entry = RouteEntry {
-            store_path:    format!("hash{i}"),
-            upstream_url:  "https://cache.nixos.org".into(),
-            latency_ms:    1.0,
-            latency_ema:   1.0,
-            last_verified: now,
-            query_count:   1,
-            failure_count: 0,
-            ttl:           now + chrono::Duration::hours(1),
-            nar_hash:      format!("sha256:{i}"),
-            nar_size:      1,
-            nar_url:       format!("nar/{i}.nar"),
-            narinfo_bytes: None,
+            store_path:       format!("hash{i}"),
+            upstream_url:     "https://cache.nixos.org".into(),
+            latency_ms:       1.0,
+            latency_ema:      1.0,
+            last_verified:    now,
+            query_count:      1,
+            failure_count:    0,
+            ttl:              now + chrono::Duration::hours(1),
+            nar_hash:         format!("sha256:{i}"),
+            nar_size:         1,
+            nar_url:          format!("nar/{i}.nar"),
+            upstream_nar_url: format!("nar/{i}.nar"),
+            narinfo_bytes:    None,
           };
           barrier.wait().await;
           db.set_route(&entry).await?;
@@ -643,18 +659,19 @@ mod tests {
   fn expired_route_is_not_valid() {
     let now = Utc::now();
     let entry = RouteEntry {
-      store_path:    "abc".into(),
-      upstream_url:  "https://cache.nixos.org".into(),
-      latency_ms:    1.0,
-      latency_ema:   1.0,
-      last_verified: now,
-      query_count:   1,
-      failure_count: 0,
-      ttl:           now - chrono::Duration::seconds(1),
-      nar_hash:      "sha256:abc".into(),
-      nar_size:      1,
-      nar_url:       "nar/abc.nar".into(),
-      narinfo_bytes: None,
+      store_path:       "abc".into(),
+      upstream_url:     "https://cache.nixos.org".into(),
+      latency_ms:       1.0,
+      latency_ema:      1.0,
+      last_verified:    now,
+      query_count:      1,
+      failure_count:    0,
+      ttl:              now - chrono::Duration::seconds(1),
+      nar_hash:         "sha256:abc".into(),
+      nar_size:         1,
+      nar_url:          "nar/abc.nar".into(),
+      upstream_nar_url: "nar/abc.nar".into(),
+      narinfo_bytes:    None,
     };
     assert!(!entry.is_valid());
     let fresh = RouteEntry {
@@ -669,18 +686,19 @@ mod tests {
     let db = Db::open(":memory:", 100, SLOW_STATEMENT_THRESHOLD).await?;
     let now = Utc::now();
     let entry = RouteEntry {
-      store_path:    "exp".into(),
-      upstream_url:  "https://cache.nixos.org".into(),
-      latency_ms:    1.0,
-      latency_ema:   1.0,
-      last_verified: now,
-      query_count:   1,
-      failure_count: 0,
-      ttl:           now - chrono::Duration::seconds(1),
-      nar_hash:      "sha256:exp".into(),
-      nar_size:      1,
-      nar_url:       "nar/exp.nar".into(),
-      narinfo_bytes: None,
+      store_path:       "exp".into(),
+      upstream_url:     "https://cache.nixos.org".into(),
+      latency_ms:       1.0,
+      latency_ema:      1.0,
+      last_verified:    now,
+      query_count:      1,
+      failure_count:    0,
+      ttl:              now - chrono::Duration::seconds(1),
+      nar_hash:         "sha256:exp".into(),
+      nar_size:         1,
+      nar_url:          "nar/exp.nar".into(),
+      upstream_nar_url: "nar/exp.nar".into(),
+      narinfo_bytes:    None,
     };
     db.set_route(&entry).await?;
     assert!(
@@ -695,23 +713,25 @@ mod tests {
     let db = Db::open(":memory:", 100, SLOW_STATEMENT_THRESHOLD).await?;
     let now = Utc::now();
     let expired = RouteEntry {
-      store_path:    "stale".into(),
-      upstream_url:  "https://cache.nixos.org".into(),
-      latency_ms:    1.0,
-      latency_ema:   1.0,
-      last_verified: now,
-      query_count:   1,
-      failure_count: 0,
-      ttl:           now - chrono::Duration::seconds(1),
-      nar_hash:      "sha256:stale".into(),
-      nar_size:      1,
-      nar_url:       "nar/stale.nar".into(),
-      narinfo_bytes: None,
+      store_path:       "stale".into(),
+      upstream_url:     "https://cache.nixos.org".into(),
+      latency_ms:       1.0,
+      latency_ema:      1.0,
+      last_verified:    now,
+      query_count:      1,
+      failure_count:    0,
+      ttl:              now - chrono::Duration::seconds(1),
+      nar_hash:         "sha256:stale".into(),
+      nar_size:         1,
+      nar_url:          "nar/stale.nar".into(),
+      upstream_nar_url: "nar/stale.nar".into(),
+      narinfo_bytes:    None,
     };
     let fresh = RouteEntry {
       store_path: "fresh".into(),
       nar_hash: "sha256:fresh".into(),
       nar_url: "nar/fresh.nar".into(),
+      upstream_nar_url: "nar/fresh.nar".into(),
       ttl: now + chrono::Duration::hours(1),
       ..expired.clone()
     };
@@ -733,18 +753,19 @@ mod tests {
     // 100 writes triggers eviction at write #100 (count 99 mod 100 == 99)
     for i in 0..100u64 {
       let entry = RouteEntry {
-        store_path:    format!("hash{i}"),
-        upstream_url:  "https://cache.nixos.org".into(),
-        latency_ms:    1.0,
-        latency_ema:   1.0,
-        last_verified: now,
-        query_count:   1,
-        failure_count: 0,
-        ttl:           now + chrono::Duration::hours(1),
-        nar_hash:      format!("sha256:{i}"),
-        nar_size:      1,
-        nar_url:       format!("nar/{i}.nar"),
-        narinfo_bytes: None,
+        store_path:       format!("hash{i}"),
+        upstream_url:     "https://cache.nixos.org".into(),
+        latency_ms:       1.0,
+        latency_ema:      1.0,
+        last_verified:    now,
+        query_count:      1,
+        failure_count:    0,
+        ttl:              now + chrono::Duration::hours(1),
+        nar_hash:         format!("sha256:{i}"),
+        nar_size:         1,
+        nar_url:          format!("nar/{i}.nar"),
+        upstream_nar_url: format!("nar/{i}.nar"),
+        narinfo_bytes:    None,
       };
       db.set_route(&entry).await?;
     }
@@ -761,18 +782,19 @@ mod tests {
     let now = Utc::now();
     for i in 0..3u64 {
       let entry = RouteEntry {
-        store_path:    format!("hash{i}"),
-        upstream_url:  "https://cache.nixos.org".into(),
-        latency_ms:    1.0,
-        latency_ema:   1.0,
-        last_verified: now,
-        query_count:   1,
-        failure_count: 0,
-        ttl:           now + chrono::Duration::hours(1),
-        nar_hash:      format!("sha256:{i}"),
-        nar_size:      1,
-        nar_url:       format!("nar/{i}.nar"),
-        narinfo_bytes: None,
+        store_path:       format!("hash{i}"),
+        upstream_url:     "https://cache.nixos.org".into(),
+        latency_ms:       1.0,
+        latency_ema:      1.0,
+        last_verified:    now,
+        query_count:      1,
+        failure_count:    0,
+        ttl:              now + chrono::Duration::hours(1),
+        nar_hash:         format!("sha256:{i}"),
+        nar_size:         1,
+        nar_url:          format!("nar/{i}.nar"),
+        upstream_nar_url: format!("nar/{i}.nar"),
+        narinfo_bytes:    None,
       };
       db.set_route(&entry).await?;
     }

--- a/crates/mesh/src/lib.rs
+++ b/crates/mesh/src/lib.rs
@@ -278,6 +278,7 @@ mod tests {
       nar_hash: "sha256:aabbcc".into(),
       nar_size: 42,
       nar_url: "nar/test.nar".into(),
+      upstream_nar_url: "nar/test.nar".into(),
       narinfo_bytes: None,
     }
   }

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -335,12 +335,13 @@ impl Router {
     url: String,
     mode: NarUrlMode,
   ) {
-    let mut map = self.inner.upstream_nar_url_modes.write().await;
-    if mode == NarUrlMode::Keep {
-      map.remove(&url);
-    } else {
-      map.insert(url, mode);
-    }
+    // `Keep` has to be stored, not skipped, since absence means the default.
+    self
+      .inner
+      .upstream_nar_url_modes
+      .write()
+      .await
+      .insert(url, mode);
   }
 
   /// Build and register a per-upstream HTTP client with a custom narinfo
@@ -378,8 +379,9 @@ impl Router {
   ) -> Result<ResolveResult, RouterError> {
     let start = Instant::now();
     let (body, _) = self.fetch_narinfo(upstream, store_hash).await?;
-    let narinfo_bytes =
-      self.response_narinfo_bytes(upstream, body.as_deref()).await;
+    let narinfo_bytes = self
+      .response_narinfo_bytes(upstream, store_hash, body.as_deref())
+      .await;
     Ok(ResolveResult {
       url: upstream.to_string(),
       latency_ms: start.elapsed().as_secs_f64() * 1000.0,
@@ -465,7 +467,11 @@ impl Router {
       let mut result = (*cached).clone();
       if result.narinfo_bytes.is_none() {
         result.narinfo_bytes = self
-          .response_narinfo_bytes(&cached.url, narinfo_bytes.as_deref())
+          .response_narinfo_bytes(
+            &cached.url,
+            store_hash,
+            narinfo_bytes.as_deref(),
+          )
           .await;
         self
           .inner
@@ -503,6 +509,7 @@ impl Router {
     let narinfo_bytes = self
       .response_narinfo_bytes(
         &entry.upstream_url,
+        store_hash,
         entry.narinfo_bytes.as_deref(),
       )
       .await;
@@ -792,14 +799,19 @@ impl Router {
       );
       return Ok(CommitOutcome::Rejected);
     }
-    // Strip leading slash and query string (harmonia appends ?hash=STORE_HASH)
-    // so the DB key is just the path component for consistent lookups.
-    let nar_url = parsed
-      .url
-      .trim_start_matches('/')
+    // harmonia appends `?hash=STORE_HASH` and needs it to locate the store
+    // path, so the fetch keeps the query and only the lookup key drops it.
+    let upstream_path = parsed.url.trim_start_matches('/');
+    let key = upstream_path
       .split_once('?')
-      .map_or_else(|| parsed.url.trim_start_matches('/'), |(path, _)| path)
-      .to_string();
+      .map_or(upstream_path, |(path, _)| path);
+    let nar_url = match self.nar_url_mode(&winner.url).await {
+      NarUrlMode::ToSelf => canonical_nar_url(&parsed.url, store_hash),
+      NarUrlMode::Keep | NarUrlMode::ToUpstream => key.to_string(),
+    };
+    // Stored `/`-prefixed and host-stripped because the NAR handler appends it
+    // to the upstream base. An upstream may publish an absolute URL here.
+    let upstream_nar_url = format!("/{}", relative_nar_url(&parsed.url));
 
     ncro_metrics::get()
       .upstream_race_wins
@@ -842,6 +854,7 @@ impl Router {
         nar_hash: parsed.nar_hash,
         nar_size: parsed.nar_size,
         nar_url,
+        upstream_nar_url,
         narinfo_bytes: body.clone(),
       })
       .await?;
@@ -850,7 +863,7 @@ impl Router {
       latency_ms:    winner.latency_ms,
       cache_hit:     false,
       narinfo_bytes: self
-        .response_narinfo_bytes(&winner.url, body.as_deref())
+        .response_narinfo_bytes(&winner.url, store_hash, body.as_deref())
         .await,
     };
     self
@@ -924,6 +937,24 @@ impl Router {
     CachedFilterCheck::Rejected
   }
 
+  /// Ask one upstream where it keeps the NAR for `store_hash`.
+  ///
+  /// A canonical path doesn't carry the upstream's layout, so retrying a
+  /// different upstream has to re-read its narinfo.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`RouterError::NotFound`] if the upstream does not have the path,
+  /// or propagates fetch, parse, and signature errors.
+  pub async fn upstream_nar_path(
+    &self,
+    upstream: &str,
+    store_hash: &str,
+  ) -> Result<String, RouterError> {
+    let (_, parsed) = self.fetch_narinfo(upstream, store_hash).await?;
+    Ok(format!("/{}", relative_nar_url(&parsed.url)))
+  }
+
   async fn fetch_narinfo(
     &self,
     upstream: &str,
@@ -974,17 +1005,20 @@ impl Router {
   async fn response_narinfo_bytes(
     &self,
     upstream: &str,
+    store_hash: &str,
     body: Option<&[u8]>,
   ) -> Option<Vec<u8>> {
     let body = body?;
-    let mode = {
-      let map = self.inner.upstream_nar_url_modes.read().await;
-      map.get(upstream).copied().unwrap_or_default()
-    };
+    let mode = self.nar_url_mode(upstream).await;
     if mode == NarUrlMode::Keep {
       return Some(body.to_vec());
     }
-    Some(rewrite_narinfo_url(body, upstream, mode))
+    Some(rewrite_narinfo_url(body, upstream, store_hash, mode))
+  }
+
+  async fn nar_url_mode(&self, upstream: &str) -> NarUrlMode {
+    let map = self.inner.upstream_nar_url_modes.read().await;
+    map.get(upstream).copied().unwrap_or_default()
   }
 }
 
@@ -1012,6 +1046,7 @@ fn narinfo_verifies_any_key(narinfo: &NarInfo, public_keys: &[String]) -> bool {
 fn rewrite_narinfo_url(
   body: &[u8],
   upstream: &str,
+  store_hash: &str,
   mode: NarUrlMode,
 ) -> Vec<u8> {
   if mode == NarUrlMode::Keep {
@@ -1029,7 +1064,7 @@ fn rewrite_narinfo_url(
     });
     if let Some(url) = line.strip_prefix("URL: ") {
       out.push_str("URL: ");
-      out.push_str(&rewrite_nar_url_value(url, upstream, mode));
+      out.push_str(&rewrite_nar_url_value(url, upstream, store_hash, mode));
     } else {
       out.push_str(line);
     }
@@ -1041,11 +1076,12 @@ fn rewrite_narinfo_url(
 fn rewrite_nar_url_value(
   url: &str,
   upstream: &str,
+  store_hash: &str,
   mode: NarUrlMode,
 ) -> String {
   match mode {
     NarUrlMode::Keep => url.to_string(),
-    NarUrlMode::ToSelf => relative_nar_url(url).to_string(),
+    NarUrlMode::ToSelf => canonical_nar_url(url, store_hash),
     NarUrlMode::ToUpstream => {
       format!(
         "{}/{}",
@@ -1054,6 +1090,31 @@ fn rewrite_nar_url_value(
       )
     },
   }
+}
+
+/// Build the `nar/<store-hash>` path NCRO serves for a NAR body.
+///
+/// Upstreams key NAR paths differently and a root-level one misses
+/// `/nar/{*path}` entirely, so only the store hash works against all of them.
+#[must_use]
+pub fn canonical_nar_url(url: &str, store_hash: &str) -> String {
+  format!("nar/{store_hash}{}", nar_extension(url))
+}
+
+fn nar_extension(url: &str) -> &str {
+  let path = relative_nar_url(url);
+  let path = path.split_once('?').map_or(path, |(path, _)| path);
+  let file = path.rsplit('/').next().unwrap_or(path);
+  file.rfind(".nar").map_or("", |idx| &file[idx..])
+}
+
+/// Recover the store hash from a [`canonical_nar_url`] path.
+#[must_use]
+pub fn store_hash_from_canonical_nar_url(path: &str) -> Option<&str> {
+  let rest = path.trim_start_matches('/').strip_prefix("nar/")?;
+  let hash = rest.split_once(".nar").map_or(rest, |(hash, _)| hash);
+  (hash.len() == 32 && hash.bytes().all(|b| b.is_ascii_alphanumeric()))
+    .then_some(hash)
 }
 
 fn relative_nar_url(url: &str) -> &str {
@@ -1157,9 +1218,11 @@ mod tests {
     NarInfo,
     Router,
     RouterTuning,
+    canonical_nar_url,
     filter_rule_matches,
     narinfo_verifies_any_key,
     rewrite_narinfo_url,
+    store_hash_from_canonical_nar_url,
     store_path_name,
     wildcard_match,
   };
@@ -1339,15 +1402,39 @@ mod tests {
     ));
   }
 
-  #[test]
-  fn narinfo_url_to_self_preserves_path_and_query() {
-    let body = b"StorePath: /nix/store/abc-hello\nURL: https://cache.example/nar/abc.nar.xz?token=1\nNarHash: sha256:abc\nNarSize: 1\n";
+  const STORE_HASH: &str = "ad4slq98kiq9ypdd35yfg0bykdwj86ba";
 
-    let rewritten =
-      rewrite_narinfo_url(body, "https://cache.example", NarUrlMode::ToSelf);
+  #[test]
+  fn narinfo_url_to_self_rewrites_to_canonical_path() {
+    // An absolute URL with no `nar/` prefix
+    let body = b"StorePath: /nix/store/abc-hello\nURL: https://blobs.example/ad4slq98kiq9ypdd35yfg0bykdwj86ba-hello-1.0.nar.xz\nNarHash: sha256:abc\nNarSize: 1\n";
+
+    let rewritten = rewrite_narinfo_url(
+      body,
+      "https://cache.example",
+      STORE_HASH,
+      NarUrlMode::ToSelf,
+    );
 
     let rewritten = String::from_utf8(rewritten).unwrap();
-    assert!(rewritten.contains("URL: nar/abc.nar.xz?token=1\n"));
+    assert!(rewritten.contains(&format!("URL: nar/{STORE_HASH}.nar.xz\n")));
+  }
+
+  #[test]
+  fn canonical_nar_url_round_trips() {
+    let url =
+      canonical_nar_url("https://blobs.example/x-foo.nar.zst", STORE_HASH);
+    assert_eq!(url, format!("nar/{STORE_HASH}.nar.zst"));
+    assert_eq!(store_hash_from_canonical_nar_url(&url), Some(STORE_HASH));
+
+    // A `nar/` path keyed on the 52-character NAR hash belongs to an upstream,
+    // so a path NCRO didn't mint must not be taken for one it did.
+    assert_eq!(
+      store_hash_from_canonical_nar_url(
+        "nar/1bpq616dpxk1pn7f9w8pw1zjs9x2q3vv3f8kmc1a9k6ha2b4mmzz.nar.xz"
+      ),
+      None
+    );
   }
 
   #[test]
@@ -1357,6 +1444,7 @@ mod tests {
     let rewritten = rewrite_narinfo_url(
       body,
       "https://cache.example/root/",
+      STORE_HASH,
       NarUrlMode::ToUpstream,
     );
 
@@ -1531,18 +1619,19 @@ mod tests {
       .inner
       .db
       .set_route(&RouteEntry {
-        store_path:    "abc123".to_string(),
-        upstream_url:  upstream.clone(),
-        latency_ms:    5.0,
-        latency_ema:   5.0,
-        last_verified: now,
-        query_count:   1,
-        failure_count: 0,
-        ttl:           now + chrono::Duration::hours(1),
-        nar_hash:      "sha256:abc".to_string(),
-        nar_size:      1,
-        nar_url:       "nar/test.nar.xz".to_string(),
-        narinfo_bytes: None,
+        store_path:       "abc123".to_string(),
+        upstream_url:     upstream.clone(),
+        latency_ms:       5.0,
+        latency_ema:      5.0,
+        last_verified:    now,
+        query_count:      1,
+        failure_count:    0,
+        ttl:              now + chrono::Duration::hours(1),
+        nar_hash:         "sha256:abc".to_string(),
+        nar_size:         1,
+        nar_url:          "nar/test.nar.xz".to_string(),
+        upstream_nar_url: "nar/test.nar.xz".to_string(),
+        narinfo_bytes:    None,
       })
       .await
       .unwrap();
@@ -1594,18 +1683,19 @@ mod tests {
       .inner
       .db
       .set_route(&RouteEntry {
-        store_path:    "abc123".to_string(),
-        upstream_url:  stale.clone(),
-        latency_ms:    5.0,
-        latency_ema:   5.0,
-        last_verified: now,
-        query_count:   1,
-        failure_count: 0,
-        ttl:           now + chrono::Duration::hours(1),
-        nar_hash:      "sha256:abc".to_string(),
-        nar_size:      1,
-        nar_url:       "nar/test.nar.xz".to_string(),
-        narinfo_bytes: None,
+        store_path:       "abc123".to_string(),
+        upstream_url:     stale.clone(),
+        latency_ms:       5.0,
+        latency_ema:      5.0,
+        last_verified:    now,
+        query_count:      1,
+        failure_count:    0,
+        ttl:              now + chrono::Duration::hours(1),
+        nar_hash:         "sha256:abc".to_string(),
+        nar_size:         1,
+        nar_url:          "nar/test.nar.xz".to_string(),
+        upstream_nar_url: "nar/test.nar.xz".to_string(),
+        narinfo_bytes:    None,
       })
       .await
       .unwrap();

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -16,7 +16,7 @@ use futures_util::TryStreamExt;
 use ncro_config::UpstreamConfig;
 use ncro_db::Db;
 use ncro_health::{Prober, Status, UpstreamHealth};
-use ncro_router::{Router, RouterError};
+use ncro_router::{Router, RouterError, store_hash_from_canonical_nar_url};
 use ncro_s3::S3ClientPool;
 use serde::Serialize;
 use tower_http::timeout::{RequestBodyTimeoutLayer, ResponseBodyTimeoutLayer};
@@ -271,16 +271,42 @@ async fn nar(
     .map_or_else(|| req.uri().path(), axum::http::uri::PathAndQuery::as_str)
     .to_string();
 
-  if let Ok(Some(entry)) = state.db.get_route_by_nar_url(&nar_url).await
-    && entry.is_valid()
-    && let Some(resp) = try_nar_upstream(
+  let routed_upstream = 'routed: {
+    let Ok(Some(entry)) = state.db.get_route_by_nar_url(&nar_url).await else {
+      break 'routed None;
+    };
+    if !entry.is_valid() {
+      break 'routed None;
+    }
+    let upstream_path = if entry.upstream_nar_url.is_empty() {
+      &path_and_query
+    } else {
+      &entry.upstream_nar_url
+    };
+    if let Some(resp) = try_nar_upstream(
       state.nar_client(&entry.upstream_url),
       &state.s3,
       req.method().clone(),
       req.headers(),
       &entry.upstream_url,
-      &path_and_query,
+      upstream_path,
       upstream_auth(&state, &entry.upstream_url),
+    )
+    .await
+    {
+      return resp;
+    }
+    Some(entry.upstream_url)
+  };
+
+  // Only a canonical path carries the store hash the other upstreams need.
+  if let Some(store_hash) = store_hash_from_canonical_nar_url(&nar_url)
+    && let Some(resp) = retry_by_store_hash(
+      &state,
+      store_hash,
+      req.method(),
+      req.headers(),
+      routed_upstream.as_deref(),
     )
     .await
   {
@@ -328,6 +354,49 @@ async fn nar(
     return resp;
   }
   StatusCode::NOT_FOUND.into_response()
+}
+
+async fn retry_by_store_hash(
+  state: &AppState,
+  store_hash: &str,
+  method: &Method,
+  headers: &HeaderMap,
+  skip: Option<&str>,
+) -> Option<Response> {
+  let mut by_priority = BTreeMap::<i32, Vec<UpstreamHealth>>::new();
+  for h in state.prober.sorted_by_latency().await {
+    if h.status == Status::Down || Some(h.url.as_str()) == skip {
+      continue;
+    }
+    by_priority.entry(h.priority).or_default().push(h);
+  }
+  for (_priority, group) in by_priority {
+    for h in group {
+      let Ok(path) = state.router.upstream_nar_path(&h.url, store_hash).await
+      else {
+        continue;
+      };
+      if let Some(resp) = try_nar_upstream(
+        state.nar_client(&h.url),
+        &state.s3,
+        method.clone(),
+        headers,
+        &h.url,
+        &path,
+        upstream_auth(state, &h.url),
+      )
+      .await
+      {
+        tracing::warn!(
+          store = store_hash,
+          upstream = h.url,
+          "nar re-routed after primary upstream failed"
+        );
+        return Some(resp);
+      }
+    }
+  }
+  None
 }
 
 async fn try_fallback_narinfo(


### PR DESCRIPTION
Some upstreams answer with an absolute `URL:` that Nix fetches directly, so a dead blob host never reaches the router, and `to_self` could not help either since reusing the upstream's own path produced something `/nar/{*path}` never matched.

Keying the rewritten path on the store hash makes it resolvable against any upstream at request time, so `ToSelf` is now the default.