### PR TITLE
nix: support multiple ncro instances via `ncro@.service`

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,10 @@ entry is used as a fallback. Config credentials always win over netrc.
 
 On NixOS, set `services.ncro.netrcFile` to pass a netrc file into the service.
 
-## NixOS Integration
+## NixOS Module
+
+This repository provides a NixOS module. You may import it and use the provided
+`services.ncro` options as below. An example NixOS setup:
 
 ```nix
 {lib, ...}: {
@@ -456,6 +459,13 @@ On NixOS, set `services.ncro.netrcFile` to pass a netrc file into the service.
   nix.settings.substituters = lib.mkForce [ "http://localhost:8080" ];
 }
 ```
+
+> [!TIP]
+> For multiple independent routers on one host, use `services.ncro.instances`;
+> the [NixOS installation guide](docs/install.md#multiple-instances) shows the
+> complete configuration.
+
+## Non-NixOS
 
 Alternatively, if you're not using NixOS, create a Systemd service similar to
 this. You'll also want to harden this, but for the sake of brevity I will not

--- a/docs/install.md
+++ b/docs/install.md
@@ -151,6 +151,33 @@ By default, the module appends every non-empty
 you may set `services.ncro.addUpstreamPublicKeys` to false. The option defaults
 to true.
 
+### Multiple instances
+
+To serve different caches from one machine, declare named instances. The module
+starts the `ncro@.service` template as `ncro@<name>.service` and gives it an
+isolated `/var/lib/ncro-<name>` state directory for each one. Each instance must
+use a unique listen address:
+
+```nix
+services.ncro = {
+  enable = true;
+  instances = {
+    public.settings = {
+      server.listen = "127.0.0.1:8081";
+      upstreams = [{ url = "https://cache.nixos.org"; }];
+    };
+
+    internal.settings = {
+      server.listen = "127.0.0.1:8082";
+      upstreams = [{ url = "https://cache.internal.example"; }];
+    };
+  };
+};
+```
+
+With any named instances, the compatibility `ncro.service` is omitted. Set
+`socketActivation = true` on an instance to create its matching socket unit.
+
 ### Discovery
 
 If you enable discovery or mesh, those settings live in the same `settings`

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
       s3 = pkgs.callPackage ./nix/tests/s3.nix {inherit self;};
       netrc = pkgs.callPackage ./nix/tests/netrc.nix {inherit self;};
       socket-activation = pkgs.callPackage ./nix/tests/socket-activation.nix {inherit self;};
+      multi-instance = pkgs.callPackage ./nix/tests/multi-instance.nix {inherit self;};
       public-keys = pkgs.callPackage ./nix/tests/public-keys.nix {inherit self;};
     });
 

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -6,7 +6,7 @@
 }: let
   inherit (lib.modules) mkIf;
   inherit (lib.options) mkOption mkEnableOption literalExpression;
-  inherit (lib.types) bool package nullOr path;
+  inherit (lib.types) attrsOf bool package nullOr path submodule;
   inherit (lib.lists) optional optionals;
   inherit (lib.attrsets) optionalAttrs;
 
@@ -32,28 +32,108 @@
     optional ((upstream.public_key or "") != "") upstream.public_key
     ++ (upstream.public_keys or []);
 
-  fallbackPublicKeys =
-    if cfg.settings.fallback_cache.enabled or false
-    then
-      publicKeysFor (
-        cfg.settings.fallback_cache
-        // {
-          public_key =
-            cfg.settings.fallback_cache.public_key
-              or "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=";
-        }
-      )
-    else [];
+  upstreamPublicKeysFor = settings: let
+    fallbackPublicKeys =
+      if settings.fallback_cache.enabled or false
+      then
+        publicKeysFor (
+          settings.fallback_cache
+          // {
+            public_key =
+              settings.fallback_cache.public_key
+                or "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=";
+          }
+        )
+      else [];
+  in
+    lib.pipe ((settings.upstreams or []) ++ [fallbackPublicKeys]) [
+      (builtins.map (upstream:
+        if builtins.isAttrs upstream
+        then publicKeysFor upstream
+        else upstream))
+      lib.flatten
+      (builtins.filter (key: key != ""))
+      lib.unique
+    ];
 
-  upstreamPublicKeys = lib.pipe ((cfg.settings.upstreams or []) ++ [fallbackPublicKeys]) [
-    (builtins.map (upstream:
-      if builtins.isAttrs upstream
-      then publicKeysFor upstream
-      else upstream))
-    lib.flatten
-    (builtins.filter (key: key != ""))
-    lib.unique
-  ];
+  instanceConfigFile = name: instance:
+    tomlFormat.generate "ncro-${name}.toml" instance.settings;
+
+  instanceWrapper = pkgs.writeShellScript "ncro-instance" ''
+    if [ -s "$CREDENTIALS_DIRECTORY/netrc" ]; then
+      export NETRC="$CREDENTIALS_DIRECTORY/netrc"
+    fi
+    exec ${lib.getExe' cfg.package "ncro"} --config "/etc/ncro/$1.toml"
+  '';
+
+  instanceService = {
+    description = "Nix Cache Route Optimizer instance %i";
+    after = ["network.target"];
+    environment.NCRO_DB_PATH = "/var/lib/ncro-%i/routes.db";
+    serviceConfig = {
+      ExecStart = "${instanceWrapper} %i";
+      Type = "notify";
+      DynamicUser = true;
+      StateDirectory = "ncro-%i";
+      LoadCredential = ["netrc:/etc/ncro/%i.netrc"];
+      Restart = "on-failure";
+      RestartSec = "5s";
+
+      NoNewPrivileges = true;
+      PrivateTmp = true;
+      PrivateDevices = true;
+      ProtectSystem = "strict";
+      ProtectHome = true;
+      ProtectProc = "invisible";
+      ProtectHostname = true;
+      ProtectClock = true;
+      ProtectControlGroups = true;
+      ProtectKernelLogs = true;
+      ProtectKernelTunables = true;
+      RestrictRealtime = true;
+      CapabilityBoundingSet = "";
+      RestrictAddressFamilies = ["AF_INET" "AF_INET6" "AF_NETLINK" "AF_UNIX"];
+      RestrictNamespaces = true;
+      LockPersonality = true;
+      MemoryDenyWriteExecute = true;
+      SystemCallFilter = ["@system-service"];
+      SystemCallArchitectures = "native";
+    };
+  };
+
+  instanceSocket = name: instance: {
+    wantedBy = ["sockets.target"];
+    socketConfig.ListenStream = toListenStream instance.settings.server.listen;
+  };
+
+  instanceListenAddresses =
+    builtins.map
+    (instance: instance.settings.server.listen)
+    (builtins.attrValues cfg.instances);
+
+  upstreamPublicKeys = lib.unique (
+    upstreamPublicKeysFor cfg.settings
+    ++ lib.flatten (builtins.map
+      (instance: upstreamPublicKeysFor instance.settings)
+      (builtins.attrValues cfg.instances))
+  );
+
+  instanceEtc =
+    lib.mapAttrs' (
+      name: instance:
+        lib.nameValuePair "ncro/${name}.toml" {source = instanceConfigFile name instance;}
+    )
+    cfg.instances
+    // lib.mapAttrs' (
+      name: instance:
+        lib.nameValuePair "ncro/${name}.netrc" {
+          source =
+            if instance.netrcFile != null
+            then instance.netrcFile
+            else pkgs.writeText "empty-netrc" "";
+        }
+    )
+    cfg.instances;
 in {
   options.services.ncro = {
     enable = mkEnableOption "ncro, the Nix cache route optimizer";
@@ -140,67 +220,139 @@ in {
         };
       };
     };
+
+    instances = mkOption {
+      type = attrsOf (submodule ({...}: {
+        options = {
+          settings = mkOption {
+            type = tomlType;
+            description = "Configuration for this ncro instance.";
+          };
+
+          socketActivation = mkOption {
+            type = bool;
+            default = false;
+            description = "Enable systemd socket activation for this instance.";
+          };
+
+          netrcFile = mkOption {
+            type = nullOr path;
+            default = null;
+            description = "Netrc file for upstream authentication in this instance.";
+          };
+        };
+      }));
+      default = {};
+      description = ''
+        Named ncro instances. Each instance starts the `ncro@.service` template
+        as `ncro@<name>.service`, with its own
+        state directory, SQLite route cache, and optionally socket unit.
+
+        Every instance must set `settings.server.listen` to a unique address.
+      '';
+      example.project = {
+        settings = {
+          server.listen = "127.0.0.1:8081";
+          upstreams = [{url = "https://cache.nixos.org";}];
+        };
+      };
+    };
   };
 
   config = mkIf cfg.enable {
     nix.settings.trusted-public-keys =
       mkIf cfg.addUpstreamPublicKeys (lib.mkAfter upstreamPublicKeys);
 
-    systemd.sockets.ncro = mkIf cfg.socketActivation {
-      wantedBy = ["sockets.target"];
-      socketConfig.ListenStream =
-        toListenStream (cfg.settings.server.listen or "");
-    };
-
-    systemd.services.ncro = {
-      description = "Nix Cache Route Optimizer";
-      wantedBy = ["multi-user.target"];
-      after =
-        if cfg.socketActivation
-        then ["ncro.socket"]
-        else ["network.target"];
-      requires = optionals cfg.socketActivation ["ncro.socket"];
-      environment = optionalAttrs (cfg.netrcFile != null) {
-        NETRC = "%d/netrc";
-      };
-      serviceConfig =
+    assertions =
+      (lib.mapAttrsToList (name: instance: {
+          assertion = instance.settings ? server && instance.settings.server ? listen;
+          message = "services.ncro.instances.${name}.settings.server.listen must be set";
+        })
+        cfg.instances)
+      ++ (lib.mapAttrsToList (name: _: {
+          assertion = builtins.match "[a-zA-Z0-9_.-]+" name != null;
+          message = "services.ncro.instances names may contain only letters, numbers, '.', '_', and '-'";
+        })
+        cfg.instances)
+      ++ [
         {
-          ExecStart = "${lib.getExe' cfg.package "ncro"} --config ${configFile}";
-          DynamicUser = true;
-          StateDirectory = "ncro";
-          Restart = "on-failure";
-          RestartSec = "5s";
-
-          # Hardening
-          NoNewPrivileges = true;
-          PrivateTmp = true;
-          PrivateDevices = true;
-          ProtectSystem = "strict";
-          ProtectHome = true;
-          ProtectProc = "invisible";
-          ProtectHostname = true;
-          ProtectClock = true;
-          ProtectControlGroups = true;
-          ProtectKernelLogs = true;
-          ProtectKernelTunables = true;
-          RestrictRealtime = true;
-          CapabilityBoundingSet = "";
-          RestrictAddressFamilies =
-            [
-              "AF_INET"
-              "AF_INET6"
-              "AF_NETLINK" # required by mdns-sd and system resolver
-            ]
-            # sd_notify uses a Unix datagram socket to signal readiness.
-            ++ optionals cfg.socketActivation ["AF_UNIX"];
-          RestrictNamespaces = true;
-          LockPersonality = true;
-          MemoryDenyWriteExecute = true;
-          SystemCallFilter = ["@system-service"];
-          SystemCallArchitectures = "native";
+          assertion = builtins.length instanceListenAddresses == builtins.length (lib.unique instanceListenAddresses);
+          message = "services.ncro.instances must use unique settings.server.listen addresses";
         }
-        // optionalAttrs cfg.socketActivation {Type = "notify";}
-        // optionalAttrs (cfg.netrcFile != null) {LoadCredential = ["netrc:${cfg.netrcFile}"];};
+      ];
+
+    systemd.sockets =
+      {
+        ncro = mkIf (cfg.instances == {} && cfg.socketActivation) {
+          wantedBy = ["sockets.target"];
+          socketConfig.ListenStream =
+            toListenStream (cfg.settings.server.listen or "");
+        };
+      }
+      // lib.mapAttrs' (
+        name: instance:
+          lib.nameValuePair "ncro@${name}" (instanceSocket name instance)
+      ) (lib.filterAttrs (_: instance: instance.socketActivation) cfg.instances);
+
+    systemd.services = {
+      ncro = mkIf (cfg.instances == {}) {
+        description = "Nix Cache Route Optimizer";
+        wantedBy = ["multi-user.target"];
+        after =
+          if cfg.socketActivation
+          then ["ncro.socket"]
+          else ["network.target"];
+        requires = optionals cfg.socketActivation ["ncro.socket"];
+        environment = optionalAttrs (cfg.netrcFile != null) {
+          NETRC = "%d/netrc";
+        };
+        serviceConfig =
+          {
+            ExecStart = "${lib.getExe' cfg.package "ncro"} --config ${configFile}";
+            DynamicUser = true;
+            StateDirectory = "ncro";
+            Restart = "on-failure";
+            RestartSec = "5s";
+
+            # Hardening
+            NoNewPrivileges = true;
+            PrivateTmp = true;
+            PrivateDevices = true;
+            ProtectSystem = "strict";
+            ProtectHome = true;
+            ProtectProc = "invisible";
+            ProtectHostname = true;
+            ProtectClock = true;
+            ProtectControlGroups = true;
+            ProtectKernelLogs = true;
+            ProtectKernelTunables = true;
+            RestrictRealtime = true;
+            CapabilityBoundingSet = "";
+            RestrictAddressFamilies =
+              [
+                "AF_INET"
+                "AF_INET6"
+                "AF_NETLINK" # required by mdns-sd and system resolver
+              ]
+              # sd_notify uses a Unix datagram socket to signal readiness.
+              ++ optionals cfg.socketActivation ["AF_UNIX"];
+            RestrictNamespaces = true;
+            LockPersonality = true;
+            MemoryDenyWriteExecute = true;
+            SystemCallFilter = ["@system-service"];
+            SystemCallArchitectures = "native";
+          }
+          // optionalAttrs cfg.socketActivation {Type = "notify";}
+          // optionalAttrs (cfg.netrcFile != null) {LoadCredential = ["netrc:${cfg.netrcFile}"];};
+      };
+      "ncro@" = mkIf (cfg.instances != {}) instanceService;
     };
+
+    environment.etc = instanceEtc;
+
+    systemd.targets.multi-user.wants =
+      builtins.map
+      (name: "ncro@${name}.service")
+      (builtins.attrNames (lib.filterAttrs (_: instance: !instance.socketActivation) cfg.instances));
   };
 }

--- a/nix/tests/multi-instance.nix
+++ b/nix/tests/multi-instance.nix
@@ -1,0 +1,44 @@
+{
+  pkgs,
+  self,
+}:
+pkgs.testers.runNixOSTest {
+  name = "ncro-multi-instance";
+
+  nodes.machine = {
+    imports = [self.nixosModules.ncro];
+
+    virtualisation.memorySize = 512;
+    networking.firewall.enable = false;
+
+    services.ncro = {
+      enable = true;
+      instances = {
+        public.settings.server.listen = "127.0.0.1:8081";
+        private = {
+          socketActivation = true;
+          settings.server.listen = "127.0.0.1:8082";
+        };
+      };
+    };
+  };
+
+  testScript = ''
+    machine.start()
+
+    with subtest("named instances start independently"):
+        machine.wait_for_unit("ncro@public.service")
+        machine.wait_for_unit("ncro@private.socket")
+        machine.succeed("! systemctl cat ncro.service")
+
+    with subtest("each instance listens on its configured address"):
+        for port in (8081, 8082):
+            out = machine.succeed(f"curl -sf http://127.0.0.1:{port}/nix-cache-info")
+            assert "StoreDir" in out, f"unexpected response on {port}: {out!r}"
+        machine.wait_for_unit("ncro@private.service")
+
+    with subtest("each instance has an isolated route database"):
+        machine.succeed("test -f /var/lib/ncro-public/routes.db")
+        machine.succeed("test -f /var/lib/ncro-private/routes.db")
+  '';
+}


### PR DESCRIPTION
Aadds support for running multiple independent `ncro` instances on a single NixOS host, each with its own configuration, state directory, and optional socket activation thanks to *glorious* Systemd featues. I've introduced a new `services.ncro.instances` option to make this happen, but non-NixOS users can trivially replicate this on their hosts since it's simply a Systemd feature. Non-Systemd users should re-evaluate their life choices.

CC @max-privatevoid for testing

Change-Id: Ifa45ac260339ab05fde631e344d12d8a6a6a6964