### PR TITLE
nix: raise LimitNOFILE for the ncro services

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -79,6 +79,11 @@
       Restart = "on-failure";
       RestartSec = "5s";
 
+      # NAR proxying is not concurrency-gated: every in-flight NAR holds an
+      # inbound and an upstream socket for the duration of the transfer, so a
+      # single busy nix client can exceed systemd's 1024 soft limit.
+      LimitNOFILE = 65536;
+
       NoNewPrivileges = true;
       PrivateTmp = true;
       PrivateDevices = true;
@@ -313,6 +318,11 @@ in {
             StateDirectory = "ncro";
             Restart = "on-failure";
             RestartSec = "5s";
+
+            # NAR proxying is not concurrency-gated: every in-flight NAR holds an
+            # inbound and an upstream socket for the duration of the transfer, so a
+            # single busy nix client can exceed systemd's 1024 soft limit.
+            LimitNOFILE = 65536;
 
             # Hardening
             NoNewPrivileges = true;


### PR DESCRIPTION
Both `ncro.service` and `ncro@.service` inherit systemd's default soft limit of 1024 file descriptors, which is low for a cache proxy.

Narinfo races are bounded — `cache.mass_query.max_concurrent_races` defaults to 64 and `per_upstream_max_inflight` to 8 — but NAR proxying in `crates/server/src/lib.rs` has no semaphore. Each in-flight NAR holds an inbound socket and an upstream socket for the entire duration of a transfer, which for something like `qtwebengine` is a few hundred MB.

That makes the inbound rate client-controlled: `max-substitution-jobs` (default 16), plus `http-connections`, which leaves the client's connection count unbounded when set to `0`.

### What it looks like when you hit it

```
{"level":"ERROR","message":"accept error: Too many open files (os error 24)"}
{"level":"WARN","message":"narinfo resolve failed",
 "error":"sqlite: (code: 14) unable to open database file"}
```

ncro stops accepting connections and its SQLite index can't be opened, so requests return 502. That part is correct behaviour — returning 502 rather than 404 means clients don't cache a negative narinfo entry. But a nix client with `fallback = true` responds to a failed substitution by building from source instead. In my case a transient burst of this turned a fully-cached `qtwebengine` — present on `cache.nixos.org` since Aug 9 — into a local Chromium compile.

### Change

`LimitNOFILE = 65536` on both units. 64× the current headroom, in line with what comparable network daemons set, and low enough that a genuine descriptor leak would still surface rather than silently consuming kernel memory.

Assisted-by: claude-code with claude-opus-5[1m]-high
